### PR TITLE
Add support for new QName of WAR artifact type

### DIFF
--- a/org.opentosca.container.engine.ia.plugin.tomcat/src/org/opentosca/container/engine/ia/plugin/tomcat/util/messages.properties
+++ b/org.opentosca.container.engine.ia.plugin.tomcat/src/org/opentosca/container/engine/ia/plugin/tomcat/util/messages.properties
@@ -2,5 +2,5 @@
 TomcatIAEnginePlugin_tomcatUsername=tcManager
 TomcatIAEnginePlugin_tomcatPassword=4Syq5MQeedIDzzP6BG7b
 TomcatIAEnginePlugin_url=http://localhost:8080
-TomcatIAEnginePlugin_types={http://www.example.com/ToscaTypes}WAR
+TomcatIAEnginePlugin_types={http://www.example.com/ToscaTypes}WAR,{http://opentosca.org/artifacttypes}WAR
 TomcatIAEnginePlugin_capabilities=http://tomcat.apache.org/tomcat7.0, http://www.jcp.org/javaserverpages2.2 , http://www.jcp.org/servlet3.0

--- a/org.opentosca.planbuilder.prephase.plugin.scriptiaonlinux/src/org/opentosca/planbuilder/prephase/plugin/scriptiaonlinux/PrePhasePlugin.java
+++ b/org.opentosca.planbuilder.prephase.plugin.scriptiaonlinux/src/org/opentosca/planbuilder/prephase/plugin/scriptiaonlinux/PrePhasePlugin.java
@@ -38,7 +38,8 @@ public class PrePhasePlugin implements IPlanBuilderPrePhaseIAPlugin, IPlanBuilde
 			"ArchiveArtifact");
 	private final QName bpelArchiveArtifactType = new QName("http://docs.oasis-open.org/wsbpel/2.0/process/executable",
 			"BPEL");
-	private final QName warArtifactType = new QName("http://www.example.com/ToscaTypes", "WAR");
+	private final QName warArtifactTypeOld = new QName("http://www.example.com/ToscaTypes", "WAR");
+	private final QName warArtifactType = new QName("http://opentosca.org/artifacttypes", "WAR");
 	private final QName sqlArtifactType = new QName("http://opentosca.org/artifacttypes", "SQLArtifact");
 	private final QName configurationArtifactType = new QName("http://opentosca.org/artifacttypes",
 			"ConfigurationArtifact");
@@ -113,7 +114,7 @@ public class PrePhasePlugin implements IPlanBuilderPrePhaseIAPlugin, IPlanBuilde
 	private boolean isSupportedDeploymentPair(final QName artifactType, final QName infrastructureNodeType,
 			final boolean isDA) {
 
-		if (!isDA && this.warArtifactType.equals(artifactType) && infrastructureNodeType
+		if (!isDA && (this.warArtifactType.equals(artifactType) || this.warArtifactTypeOld.equals(artifactType)) && infrastructureNodeType
 				.equals(new QName("http://opentosca.org/nodetypes", "TOSCAManagmentInfrastructure"))) {
 			// WARs are deployed as environment-centric artifacts -> doesn't
 			// need to be deployed on a node inside the topology, instead we
@@ -144,6 +145,10 @@ public class PrePhasePlugin implements IPlanBuilderPrePhaseIAPlugin, IPlanBuilde
 		}
 
 		if (this.warArtifactType.equals(artifactType)) {
+			isSupportedArtifactType |= true;
+		}
+
+		if (this.warArtifactTypeOld.equals(artifactType)) {
 			isSupportedArtifactType |= true;
 		}
 
@@ -178,7 +183,8 @@ public class PrePhasePlugin implements IPlanBuilderPrePhaseIAPlugin, IPlanBuilde
 	@Override
 	public boolean handle(final TemplatePlanContext context, final AbstractImplementationArtifact ia,
 			final AbstractNodeTemplate nodeTemplate) {
-		if (ia.getArtifactType().equals(this.warArtifactType)) {
+		QName type = ia.getArtifactType();
+		if (type.equals(this.warArtifactType) || type.equals(this.warArtifactTypeOld)) {
 			// provisioning of IA that are webservice war files, is in the
 			// responsibility of
 			// the opentosca IA Engine. We just let the planbuilder know that


### PR DESCRIPTION
We are cleaning up the QNames of the types in the OpenTOSCA eco system - see https://github.com/OpenTOSCA/tosca-definitions. The namespace of the WAR type had to be adapted, too. This PR implements that.