### PR TITLE
new name and namespace for 'DockerContainerArtifact'

### DIFF
--- a/org.opentosca.planbuilder.prephase.plugin.scriptiaonlinux/src/org/opentosca/planbuilder/prephase/plugin/scriptiaonlinux/PrePhasePlugin.java
+++ b/org.opentosca.planbuilder.prephase.plugin.scriptiaonlinux/src/org/opentosca/planbuilder/prephase/plugin/scriptiaonlinux/PrePhasePlugin.java
@@ -47,9 +47,11 @@ public class PrePhasePlugin implements IPlanBuilderPrePhaseIAPlugin, IPlanBuilde
 
 	private final QName ansibleArtifactType = new QName("http://opentosca.org/artifacttypes", "Ansible");
 	private final QName chefArtifactType = new QName("http://opentosca.org/artifacttypes", "Chef");
-	private final QName dockerContainerArtefactType = new QName("http://opentosca.org/artefacttypes",
+	private final QName dockerContainerArtefactTypeOld = new QName("http://opentosca.org/artefacttypes",
 			"DockerContainerArtefact");
-
+	private final QName dockerContainerArtefactType = new QName("http://opentosca.org/artifacttypes",
+			"DockerContainerArtifact");
+	
 	private final Handler handler = new Handler();
 
 	/**
@@ -160,6 +162,10 @@ public class PrePhasePlugin implements IPlanBuilderPrePhaseIAPlugin, IPlanBuilde
 			isSupportedArtifactType |= true;
 		}
 
+		if (this.dockerContainerArtefactTypeOld.equals(artifactType)) {
+			isSupportedArtifactType |= true;
+		}
+		
 		if (this.dockerContainerArtefactType.equals(artifactType)) {
 			isSupportedArtifactType |= true;
 		}
@@ -202,7 +208,7 @@ public class PrePhasePlugin implements IPlanBuilderPrePhaseIAPlugin, IPlanBuilde
 	public boolean handle(final TemplatePlanContext context, final AbstractDeploymentArtifact da,
 			final AbstractNodeTemplate nodeTemplate) {
 
-		if (da.getArtifactType().equals(this.dockerContainerArtefactType)) {
+		if (da.getArtifactType().equals(this.dockerContainerArtefactType) || da.getArtifactType().equals(this.dockerContainerArtefactTypeOld)) {
 			return true;
 		}
 

--- a/org.opentosca.planbuilder.type.plugin.dockercontainer/src/org/opentosca/planbuilder/type/plugin/dockercontainer/PluginConstants.java
+++ b/org.opentosca.planbuilder.type.plugin.dockercontainer/src/org/opentosca/planbuilder/type/plugin/dockercontainer/PluginConstants.java
@@ -12,5 +12,6 @@ import javax.xml.namespace.QName;
 public class PluginConstants {
 
 	public final static QName dockerContainerNodeType = new QName("http://opentosca.org/nodetype", "DockerContainer");
-	public final static QName dockerContainerArtefactType = new QName("http://opentosca.org/artefacttypes", "DockerContainerArtefact");
+	public final static QName dockerContainerArtefactTypeOld = new QName("http://opentosca.org/artefacttypes", "DockerContainerArtefact");
+	public final static QName dockerContainerArtefactType = new QName("http://opentosca.org/artifacttypes", "DockerContainerArtifact");
 }

--- a/org.opentosca.planbuilder.type.plugin.dockercontainer/src/org/opentosca/planbuilder/type/plugin/dockercontainer/handler/Handler.java
+++ b/org.opentosca.planbuilder.type.plugin.dockercontainer/src/org/opentosca/planbuilder/type/plugin/dockercontainer/handler/Handler.java
@@ -204,14 +204,14 @@ public class Handler {
 
 	public AbstractDeploymentArtifact fetchFirstDockerContainerDA(final AbstractNodeTemplate nodeTemplate) {
 		for (final AbstractDeploymentArtifact da : nodeTemplate.getDeploymentArtifacts()) {
-			if (da.getArtifactType().equals(PluginConstants.dockerContainerArtefactType)) {
+			if (da.getArtifactType().equals(PluginConstants.dockerContainerArtefactType) || da.getArtifactType().equals(PluginConstants.dockerContainerArtefactTypeOld)) {
 				return da;
 			}
 		}
 
 		for (final AbstractNodeTypeImplementation nodeTypeImpl : nodeTemplate.getImplementations()) {
 			for (final AbstractDeploymentArtifact da : nodeTypeImpl.getDeploymentArtifacts()) {
-				if (da.getArtifactType().equals(PluginConstants.dockerContainerArtefactType)) {
+				if (da.getArtifactType().equals(PluginConstants.dockerContainerArtefactType) || da.getArtifactType().equals(PluginConstants.dockerContainerArtefactTypeOld)) {
 					return da;
 				}
 			}


### PR DESCRIPTION
#### Short Description
<!-- Add a short description of what this pull request resolves -->
These changes should fix spelling of the Docker container artifact and its namespace

#### Proposed Changes
<!-- List all changes proposed in this pull request -->

  * namespace changed from 'opentosca.org/artefacttype' to 'opentosca.org/artifacttype'
  * artifact name changed from 'DockerContainerArtefact' to 'DockerContainerArtifact'
  * old name and namespace are still supported

