### PR TITLE
Fix for the badge order in the readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 
+# OpenTOSCA Container - TOSCA Runtime
+
 [![Build Status](https://travis-ci.org/OpenTOSCA/container.svg?branch=master)](https://travis-ci.org/OpenTOSCA/container)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-
-# OpenTOSCA Container - TOSCA Runtime
 
 Part of the [OpenTOSCA Ecosystem](http://www.opentosca.org)
 


### PR DESCRIPTION
#### Short Description
Badges are now directly under the header which is their correct position.