### PR TITLE
Fix nullpointer when no interface is defined

### DIFF
--- a/org.opentosca.bus.management/src/org/opentosca/bus/management/utils/MBUtils.java
+++ b/org.opentosca.bus.management/src/org/opentosca/bus/management/utils/MBUtils.java
@@ -202,9 +202,10 @@ public class MBUtils {
 
                 MBUtils.LOG.debug("Interface: {} ", osIAInterface);
 
-                if (osIAInterface.equals(Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM)
-                    | osIAInterface.equals(Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_DOCKERCONTAINER)) {
-
+                if (osIAInterface == null
+                    || osIAInterface.equals(Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM)
+                    || osIAInterface.equals(Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_DOCKERCONTAINER)) {
+                  
                     return osIAName;
 
                 }


### PR DESCRIPTION
#### Short Description
This changes fix a nullpointer exception when an IA with no interface is defined in a NodeTypeImplementation for a NodeType, that is a operating system. The current implementation accepts only IAs with defined OperatingSystemInterface but no interface should be accepted too, as it states that all Interfaces of the NodeType are supported by this IA.


