### PR TITLE
adds feature that enables to attach files as a docker volume to docker containers

### DIFF
--- a/org.opentosca.planbuilder.type.plugin.dockercontainer/src/org/opentosca/planbuilder/type/plugin/dockercontainer/core/DockerContainerTypePluginPluginConstants.java
+++ b/org.opentosca.planbuilder.type.plugin.dockercontainer/src/org/opentosca/planbuilder/type/plugin/dockercontainer/core/DockerContainerTypePluginPluginConstants.java
@@ -18,6 +18,10 @@ public class DockerContainerTypePluginPluginConstants {
         new QName("http://opentosca.org/artefacttypes", "DockerContainerArtefact");
     public final static QName DOCKER_CONTAINER_ARTEFACTTYPE =
         new QName("http://opentosca.org/artifacttypes", "DockerContainerArtifact");
+
+    public final static QName DOCKER_VOLUME_ARTIFACTTYPE =
+        new QName("http://opentosca.org/artifacttypes", "DockerVolumeArtifact_1-w1-wip1");
+
     public final static QName OPENMTC_BACKEND_SERVICE_NODETYPE = new QName("http://opentosca.org/nodetypes", "OpenMTC");
     public final static QName OPENMTC_GATEWAY_DOCKER_CONTAINER_NODETYPE =
         new QName("http://opentosca.org/nodetypes", "OpenMTCDockerContainerGateway");


### PR DESCRIPTION
#### Short Description
- enables to set deployment artifacts on docker container node types
- enables to add local file paths stored on the docker engine host that are then added to a started docker container
- enables to to read properties form other templates inside the docker container properties

#### Proposed Changes
Basically, enables to model Docker Containers like below. While the attached deployment artifacts are the files to be copied into a volume and attached to the container, ContainerMountPath controls where the volume with the DAs are mounted. HostMountFiles allows to add files to the volume from the Docker Engine Hosts (!) storage, allowing e.g. to add files that are uploaded to the  virtual machine running the docker engine.

Additional small feature for docker containers:
With get_property properties of the docker container can be set from other property sources and concatenated with strings like in the property <ENV_BROKER_EP> in the example below.



```xml
<NodeTemplate type="otntyIversioned:OpenMTC_MqttConnector_1-w1-wip1" id="OpenMTC_MqttConnector_1-w1-wip1">
                <Properties>
                    <Properties>
                        <Port/>
                        <ContainerPort/>
                        <SSHPort/>
                        <ContainerID/>
                        <ContainerIP/>
                        <ImageID/>
                        <ContainerMountPath>/etc/openmtc/certs</ContainerMountPath>
                        <HostMountFiles>/home/ubuntu/ca-smartorchestra.crt</HostMountFiles>
                        <ENV_EP>get_input: OpenMTCBackend.Endpoint</ENV_EP>
                        <ENV_ORIGINATOR_PRE>get_input: OpenMTCBackend.Originator</ENV_ORIGINATOR_PRE>
                        <ENV_SSL_CRT>/etc/openmtc/certs/mqtt-connector.cert.pem</ENV_SSL_CRT>
                        <ENV_SSL_KEY>/etc/openmtc/certs/mqtt-connector.key.pem</ENV_SSL_KEY>
                        <ENV_BROKER_EP>[get_property: Ubuntu-VM_14.04-w1 VMIP]:8883</ENV_BROKER_EP>
                        <ENV_TOPIC_PRE>get_input</ENV_TOPIC_PRE>
                        <ENV_TOPIC_INDEX_LOCATION>1</ENV_TOPIC_INDEX_LOCATION>
                        <ENV_TOPIC_INDEX_DEVICE>2</ENV_TOPIC_INDEX_DEVICE>
                        <ENV_FIWARE_SERVICE>get_input: FIWARE_Service</ENV_FIWARE_SERVICE>
                        <ENV_MQTTS_ENABLED>true</ENV_MQTTS_ENABLED>
                        <ENV_MQTTS_CA_CERTS>/etc/openmtc/certs/ca-smartorchestra.crt</ENV_MQTTS_CA_CERTS>
                    </Properties>
                </Properties>
                <Requirements/>
                <Capabilities/>
                <Policies/>
                <DeploymentArtifacts>
                    <DeploymentArtifact xmlns:otatyIgeneral="http://opentosca.org/artifacttypes" xmlns:otateIversioned="http://opentosca.org/artifacttemplates/versioned" name="OpenMTC_MqttConnector_DockerImage_DA" artifactType="otatyIgeneral:DockerContainerArtifact" artifactRef="otateIversioned:OpenMTC_MqttConnector_DockerImage_AT"/>
                    <DeploymentArtifact xmlns:otatyIgeneral="http://opentosca.org/artifacttypes" xmlns:otateIgeneral="http://opentosca.org/artifacttemplates" name="ca-chain.cert_DA" artifactType="otatyIgeneral:DockerVolumeArtifact_1-w1-wip1" artifactRef="otateIgeneral:CA-Chain"/>
                    <DeploymentArtifact xmlns:otatyIgeneral="http://opentosca.org/artifacttypes" xmlns:otateIgeneral="http://opentosca.org/artifacttemplates" name="ca-smartorchestra.crt" artifactType="otatyIgeneral:DockerVolumeArtifact_1-w1-wip1" artifactRef="otateIgeneral:Ca-SmartOrchestra.crt"/>
                    <DeploymentArtifact xmlns:otatyIgeneral="http://opentosca.org/artifacttypes" xmlns:otateIgeneral="http://opentosca.org/artifacttemplates" name="Mqtt-Connector.Cert" artifactType="otatyIgeneral:DockerVolumeArtifact_1-w1-wip1" artifactRef="otateIgeneral:Mqtt-Connector.Cert_AT"/>
                    <DeploymentArtifact xmlns:otatyIgeneral="http://opentosca.org/artifacttypes" xmlns:otateIgeneral="http://opentosca.org/artifacttemplates" name="Mqtt-Connector-Key" artifactType="otatyIgeneral:DockerVolumeArtifact_1-w1-wip1" artifactRef="otateIgeneral:Mqtt-Connector-Key"/>
                </DeploymentArtifacts>
</NodeTemplate>```
