### PR TITLE
[Feature] Improve environment variable handling for DockerContainer NodeTypes

### DIFF
--- a/org.opentosca.planbuilder.type.plugin.dockercontainer/src/org/opentosca/planbuilder/type/plugin/dockercontainer/bpel/handler/BPELDockerContainerTypePluginHandler.java
+++ b/org.opentosca.planbuilder.type.plugin.dockercontainer/src/org/opentosca/planbuilder/type/plugin/dockercontainer/bpel/handler/BPELDockerContainerTypePluginHandler.java
@@ -269,29 +269,51 @@ public class BPELDockerContainerTypePluginHandler implements DockerContainerType
             if (propName.startsWith("ENV_")) {
                 final Variable propVar = context.getPropertyVariable(nodeTemplate, propName);
 
-                final String varContent = context.getVariableContent(propVar, context);
+                String varContent = context.getVariableContent(propVar, context);
 
                 // FIXME brutal hack right now
                 if (varContent.contains("get_property")) {
-                    if (varContent.startsWith("[")) {
-
-                        // fetch static content
-                        final String staticContent = varContent.substring(varContent.lastIndexOf(']') + 1);
-
-                        String dynamicContent = varContent.substring(1);
-                        dynamicContent = dynamicContent.substring(0, dynamicContent.lastIndexOf(']'));
-
-                        final String[] splits = dynamicContent.split(" ");
-                        final String nodeTemplateId = splits[1];
-                        final String propertyName = splits[2];
-
-                        final AbstractNodeTemplate refNode = getNode(nodeTemplateId, context);
-                        final Variable refProp = context.getPropertyVariable(refNode, propertyName);
+                    // concatenation required
+                    if (varContent.contains("[") && varContent.contains("]")) {
 
                         foundEnvVar = true;
                         final String envVarName = propName.replaceFirst("ENV_", "");
-                        envVarXpathQuery +=
-                            "'" + envVarName + "=',$" + refProp.getName() + ",'" + staticContent + ";',";
+                        envVarXpathQuery += "'" + envVarName + "='";
+
+                        while (!varContent.isEmpty()) {
+
+                            final int startIndex = varContent.indexOf("[");
+                            final int endIndex = varContent.indexOf("]");
+
+                            if (startIndex == 0) {
+
+                                final String dynamicContent = varContent.substring(startIndex, endIndex);
+
+                                final String[] splits = dynamicContent.split(" ");
+                                final String nodeTemplateId = splits[1];
+                                final String propertyName = splits[2];
+
+                                final AbstractNodeTemplate refNode = getNode(nodeTemplateId, context);
+                                final Variable refProp = context.getPropertyVariable(refNode, propertyName);
+
+                                envVarXpathQuery += ",$" + refProp.getName();
+                                varContent = varContent.replace(dynamicContent + "]", "");
+
+
+                            } else {
+                                String staticContent;
+                                if (startIndex == -1) {
+                                    staticContent = varContent;
+                                } else {
+                                    staticContent = varContent.substring(0, startIndex);
+                                }
+
+                                envVarXpathQuery += ",'" + staticContent + "'";
+                                varContent = varContent.replace(staticContent, "");
+                            }
+                        }
+                        envVarXpathQuery += ",';',";
+
                     } else {
                         final String[] splits = varContent.split(" ");
                         final String nodeTemplateId = splits[1];


### PR DESCRIPTION
#### Short Description
The DockerContainer NodeType enables to specify environment variables in inheriting NodeTypes, that are passed to the container when it is started.
This PR allows to specify multiple environment variables in one property as well as at any place.