### PR TITLE
fixes issue when starting Containers from ImageID

### DIFF
--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/BPELTerminationProcessBuilder.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/BPELTerminationProcessBuilder.java
@@ -243,7 +243,7 @@ public class BPELTerminationProcessBuilder extends AbstractTerminationPlanBuilde
                 check++;
             } else if (childNodeList.item(index).getLocalName().equals("Port")) {
                 check++;
-            } else if (childNodeList.item(index).getLocalName().equals("ContainerImage")) {
+            } else if (childNodeList.item(index).getLocalName().equals("ImageID")) {
                 foundDockerImageProp = true;
             }
         }

--- a/org.opentosca.planbuilder.type.plugin.dockercontainer/src/org/opentosca/planbuilder/type/plugin/dockercontainer/bpel/handler/BPELDockerContainerTypePluginHandler.java
+++ b/org.opentosca.planbuilder.type.plugin.dockercontainer/src/org/opentosca/planbuilder/type/plugin/dockercontainer/bpel/handler/BPELDockerContainerTypePluginHandler.java
@@ -119,7 +119,7 @@ public class BPELDockerContainerTypePluginHandler implements DockerContainerType
         final Variable dockerEngineUrlVar = templateContext.getPropertyVariable(dockerEngineNode, "DockerEngineURL");
 
         // determine whether we work with an ImageId or a zipped DockerContainer
-        final Variable containerImageVar = templateContext.getPropertyVariable(nodeTemplate, "ContainerImage");
+        final Variable containerImageVar = templateContext.getPropertyVariable(nodeTemplate, "ImageID");
 
 
 

--- a/org.opentosca.planbuilder.type.plugin.dockercontainer/src/org/opentosca/planbuilder/type/plugin/dockercontainer/bpel/handler/BPELOpenMTCDockerContainerTypePluginHandler.java
+++ b/org.opentosca.planbuilder.type.plugin.dockercontainer/src/org/opentosca/planbuilder/type/plugin/dockercontainer/bpel/handler/BPELOpenMTCDockerContainerTypePluginHandler.java
@@ -169,7 +169,7 @@ public class BPELOpenMTCDockerContainerTypePluginHandler implements
         final Variable dockerEngineUrlVar = templateContext.getPropertyVariable(dockerEngineNode, "DockerEngineURL");
 
         // determine whether we work with an ImageId or a zipped DockerContainer
-        final Variable containerImageVar = templateContext.getPropertyVariable(nodeTemplate, "ContainerImage");
+        final Variable containerImageVar = templateContext.getPropertyVariable(nodeTemplate, "ImageID");
 
         if (containerImageVar == null || BPELPlanContext.isVariableValueEmpty(containerImageVar, templateContext)) {
             // handle with DA -> construct URL to the DockerImage .zip
@@ -371,7 +371,7 @@ public class BPELOpenMTCDockerContainerTypePluginHandler implements
         final Variable dockerEngineUrlVar = templateContext.getPropertyVariable(dockerEngineNode, "DockerEngineURL");
 
         // determine whether we work with an ImageId or a zipped DockerContainer
-        final Variable containerImageVar = templateContext.getPropertyVariable(nodeTemplate, "ContainerImage");
+        final Variable containerImageVar = templateContext.getPropertyVariable(nodeTemplate, "ImageID");
 
         if (containerImageVar == null || BPELPlanContext.isVariableValueEmpty(containerImageVar, templateContext)) {
             // handle with DA -> construct URL to the DockerImage .zip

--- a/org.opentosca.planbuilder.type.plugin.dockercontainer/src/org/opentosca/planbuilder/type/plugin/dockercontainer/core/DockerContainerTypePlugin.java
+++ b/org.opentosca.planbuilder.type.plugin.dockercontainer/src/org/opentosca/planbuilder/type/plugin/dockercontainer/core/DockerContainerTypePlugin.java
@@ -6,13 +6,13 @@ import java.util.List;
 import javax.xml.namespace.QName;
 import javax.xml.soap.Node;
 
-import org.opentosca.planbuilder.plugins.IPlanBuilderTypePlugin;
-import org.opentosca.planbuilder.plugins.context.PlanContext;
 import org.opentosca.planbuilder.model.tosca.AbstractDeploymentArtifact;
 import org.opentosca.planbuilder.model.tosca.AbstractNodeTemplate;
 import org.opentosca.planbuilder.model.tosca.AbstractNodeTypeImplementation;
 import org.opentosca.planbuilder.model.tosca.AbstractRelationshipTemplate;
 import org.opentosca.planbuilder.model.utils.ModelUtils;
+import org.opentosca.planbuilder.plugins.IPlanBuilderTypePlugin;
+import org.opentosca.planbuilder.plugins.context.PlanContext;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
@@ -117,7 +117,7 @@ public abstract class DockerContainerTypePlugin<T extends PlanContext> implement
                 check++;
             } else if (childNodeList.item(index).getLocalName().equals("Port")) {
                 check++;
-            } else if (childNodeList.item(index).getLocalName().equals("ContainerImage")) {
+            } else if (childNodeList.item(index).getLocalName().equals("ImageID")) {
                 foundDockerImageProp = true;
             }
         }

--- a/org.opentosca.planbuilder.type.plugin.dockercontainer/src/org/opentosca/planbuilder/type/plugin/dockercontainer/core/OpenMTCDockerContainerTypePlugin.java
+++ b/org.opentosca.planbuilder.type.plugin.dockercontainer/src/org/opentosca/planbuilder/type/plugin/dockercontainer/core/OpenMTCDockerContainerTypePlugin.java
@@ -119,7 +119,7 @@ public abstract class OpenMTCDockerContainerTypePlugin<T extends PlanContext> im
                 check++;
             } else if (childNodeList.item(index).getLocalName().equals("Port")) {
                 check++;
-            } else if (childNodeList.item(index).getLocalName().equals("ContainerImage")) {
+            } else if (childNodeList.item(index).getLocalName().equals("ImageID")) {
                 foundDockerImageProp = true;
             }
         }

--- a/org.opentosca.planbuilder.type.plugin.ubuntuvm/src/org/opentosca/planbuilder/type/plugin/ubuntuvm/bpel/BPELUbuntuVmTypePluginHandler.java
+++ b/org.opentosca.planbuilder.type.plugin.ubuntuvm/src/org/opentosca/planbuilder/type/plugin/ubuntuvm/bpel/BPELUbuntuVmTypePluginHandler.java
@@ -830,7 +830,7 @@ public class BPELUbuntuVmTypePluginHandler implements UbuntuVmTypePluginHandler<
 
         // create variable with image --> currently ubuntu 14.04 hard coded
         // TODO: map ubuntu template name to docker image name
-        final Variable containerImageVariable = context.createGlobalStringVariable("containerImage", "ubuntu:14.04");
+        final Variable containerImageVariable = context.createGlobalStringVariable("ImageID", "ubuntu:14.04");
 
         // find ServerIp Property inside ubuntu nodeTemplate
         Variable serverIpPropWrapper = null;
@@ -928,7 +928,7 @@ public class BPELUbuntuVmTypePluginHandler implements UbuntuVmTypePluginHandler<
         createDEInternalExternalPropsInput.put("ContainerImage", containerImageVariable);
 
         createDEInternalExternalPropsOutput.put("ContainerIP", serverIpPropWrapper);
-        createDEInternalExternalPropsOutput.put("ContainerID", instanceIdPropWrapper);
+        createDEInternalExternalPropsOutput.put("ImageID", instanceIdPropWrapper);
 
         LOG.debug(dockerEngineNodeTemplate.getId() + " " + dockerEngineNodeTemplate.getType());
         this.invokerOpPlugin.handle(context, dockerEngineNodeTemplate.getId(), true,


### PR DESCRIPTION
somehow the Property name didn't match what the docker container plugin searched  for

#### Short Description
DockerContainer NodeType got instead of ContainerImage the ImageID property which enables to set an image Id from dockerhub.

#### Proposed Changes
* changes PlanBuilder Plugin for dockercontainers to search for the right property
