### PR TITLE
Implement Basic NodeTypeImplementation Chooser

### DIFF
--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/BPELBuildProcessBuilder.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/BPELBuildProcessBuilder.java
@@ -276,7 +276,7 @@ public class BPELBuildProcessBuilder extends AbstractBuildPlanBuilder {
                 if (plugin == null) {
                     BPELBuildProcessBuilder.LOG.debug("Handling NodeTemplate {} with ProvisioningChain",
                                                       nodeTemplate.getId());
-                    final OperationChain chain = BPELScopeBuilder.createOperationChain(nodeTemplate);
+                    final OperationChain chain = BPELScopeBuilder.createOperationChain(nodeTemplate, this.opNames);
                     if (chain == null) {
                         BPELBuildProcessBuilder.LOG.warn("Couldn't create ProvisioningChain for NodeTemplate {}",
                                                          nodeTemplate.getId());

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/BPELScaleOutProcessBuilder.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/BPELScaleOutProcessBuilder.java
@@ -640,7 +640,7 @@ public class BPELScaleOutProcessBuilder extends AbstractScaleOutPlanBuilder {
         if (plugin == null) {
             BPELScaleOutProcessBuilder.LOG.debug("Handling NodeTemplate {} with ProvisioningChain",
                                                  nodeTemplate.getId());
-            final OperationChain chain = BPELScopeBuilder.createOperationChain(nodeTemplate);
+            final OperationChain chain = BPELScopeBuilder.createOperationChain(nodeTemplate, this.opNames);
             if (chain == null) {
                 BPELScaleOutProcessBuilder.LOG.warn("Couldn't create ProvisioningChain for NodeTemplate {}",
                                                     nodeTemplate.getId());

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/BPELScopeBuilder.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/BPELScopeBuilder.java
@@ -223,9 +223,11 @@ public class BPELScopeBuilder {
         BPELScopeBuilder.reorderProvCandidates(chain);
 
         // TODO consistency plugins
+        final List<String> array= new ArrayList<>();
 
+        array.add(operationName);
         // select provisioning
-        BPELScopeBuilder.selectProvisioning(chain);
+        BPELScopeBuilder.selectProvisioning(chain, array);
 
         return chain;
     }
@@ -236,7 +238,7 @@ public class BPELScopeBuilder {
      * @param nodeTemplate an AbstractNodeTemplate to create a ProvisioningChain for
      * @return a complete ProvisioningChain
      */
-    public static OperationChain createOperationChain(final AbstractNodeTemplate nodeTemplate) {
+    public static OperationChain createOperationChain(final AbstractNodeTemplate nodeTemplate, final List<String> operationNames) {
         // get nodetype implementations
         final List<AbstractNodeTypeImplementation> nodeTypeImpls = nodeTemplate.getImplementations();
 
@@ -314,7 +316,8 @@ public class BPELScopeBuilder {
         // TODO consistency plugins
 
         // select provisioning
-        BPELScopeBuilder.selectProvisioning(chain);
+        BPELScopeBuilder.selectProvisioning(chain, operationNames);
+
 
         return chain;
     }
@@ -460,11 +463,34 @@ public class BPELScopeBuilder {
         }
     }
 
-    private static void selectProvisioning(final OperationChain chain) {
+    private static void selectProvisioning(final OperationChain chain, final List<String> operationNames) {
         // TODO just select the first ia candidate, da candidate and prov
         // candidate for now
         // Selection should determine a minimal provisioning. Minimal=
         // min{|IACandidates| + |DACandidates| +|ProvPhaseOperations|}
+
+        // select first candidate set where the provisioning candidate uses the given operations
+
+        int selectedCandidateSet = -1;
+        for(int i = 0 ; i <chain.provCandidates.size() ; i++) {
+
+            for(final AbstractOperation op : chain.provCandidates.get(i).ops) {
+                if(operationNames.contains(op.getName())) {
+                    selectedCandidateSet = i;
+                    break;
+                }
+            }
+            if(selectedCandidateSet != -1 ) {
+                break;
+            }
+        }
+
+
+        if(selectedCandidateSet != -1) {
+            chain.selectedCandidateSet = selectedCandidateSet;
+        }
+
+
     }
 
     /**

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/OperationChain.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/OperationChain.java
@@ -42,6 +42,9 @@ public class OperationChain {
     List<IANodeTypeImplCandidate> iaCandidates = new ArrayList<>();
     List<OperationNodeTypeImplCandidate> provCandidates = new ArrayList<>();
 
+    // select candidate set
+    int selectedCandidateSet = 0;
+
     /**
      * <p>
      * Constructor for a NodeTemplate
@@ -87,7 +90,7 @@ public class OperationChain {
     public boolean executeDAProvisioning(final BPELPlanContext context) {
         boolean check = true;
         if (!this.daCandidates.isEmpty()) {
-            final DANodeTypeImplCandidate daCandidate = this.daCandidates.get(0);
+            final DANodeTypeImplCandidate daCandidate = this.daCandidates.get(this.selectedCandidateSet);
             for (int index = 0; index < daCandidate.das.size(); index++) {
                 final AbstractDeploymentArtifact da = daCandidate.das.get(index);
                 final AbstractNodeTemplate infraNode = daCandidate.infraNodes.get(index);
@@ -121,7 +124,7 @@ public class OperationChain {
     public boolean executeIAProvisioning(final BPELPlanContext context) {
         boolean check = true;
         if (!this.iaCandidates.isEmpty()) {
-            final IANodeTypeImplCandidate iaCandidate = this.iaCandidates.get(0);
+            final IANodeTypeImplCandidate iaCandidate = this.iaCandidates.get(this.selectedCandidateSet);
             for (int index = 0; index < iaCandidate.ias.size(); index++) {
                 final AbstractImplementationArtifact ia = iaCandidate.ias.get(index);
                 final AbstractNodeTemplate infraNode = iaCandidate.infraNodes.get(index);
@@ -155,7 +158,7 @@ public class OperationChain {
     public boolean executeOperationProvisioning(final BPELPlanContext context) {
         boolean check = true;
         if (!this.provCandidates.isEmpty()) {
-            final OperationNodeTypeImplCandidate provCandidate = this.provCandidates.get(0);
+            final OperationNodeTypeImplCandidate provCandidate = this.provCandidates.get(this.selectedCandidateSet);
             for (int index = 0; index < provCandidate.ops.size(); index++) {
                 final AbstractOperation op = provCandidate.ops.get(index);
                 final AbstractImplementationArtifact ia = provCandidate.ias.get(index);
@@ -189,7 +192,7 @@ public class OperationChain {
     public boolean executeOperationProvisioning(final BPELPlanContext context, final List<String> operationNames) {
         boolean check = true;
         if (!this.provCandidates.isEmpty()) {
-            final OperationNodeTypeImplCandidate provCandidate = this.provCandidates.get(0);
+            final OperationNodeTypeImplCandidate provCandidate = this.provCandidates.get(this.selectedCandidateSet);
             final Map<String, Integer> order = new HashMap<>();
             // check for index of prov candidates
             for (final String opName : operationNames) {
@@ -235,7 +238,7 @@ public class OperationChain {
                                                 final Map<AbstractParameter, Variable> param2propertyMapping) {
         int checkCount = 0;
         if (!this.provCandidates.isEmpty()) {
-            final OperationNodeTypeImplCandidate provCandidate = this.provCandidates.get(0);
+            final OperationNodeTypeImplCandidate provCandidate = this.provCandidates.get(this.selectedCandidateSet);
             final Map<String, Integer> order = new HashMap<>();
             // check for index of prov candidates
             for (final String opName : operationNames) {
@@ -304,9 +307,10 @@ public class OperationChain {
     public boolean executeOperationProvisioning(final BPELPlanContext context, final List<String> operationNames,
                                                 final Map<AbstractParameter, Variable> param2propertyMapping,
                                                 final Map<AbstractParameter, Variable> param2propertyOutputMapping) {
+
         int checkCount = 0;
         if (!this.provCandidates.isEmpty()) {
-            final OperationNodeTypeImplCandidate provCandidate = this.provCandidates.get(0);
+            final OperationNodeTypeImplCandidate provCandidate = this.provCandidates.get(this.selectedCandidateSet);
             final Map<String, Integer> order = new HashMap<>();
             // check for index of prov candidates
             for (final String opName : operationNames) {
@@ -402,7 +406,7 @@ public class OperationChain {
                                                 final BPELScopePhaseType phase) {
         int checkCount = 0;
         if (!this.provCandidates.isEmpty()) {
-            final OperationNodeTypeImplCandidate provCandidate = this.provCandidates.get(0);
+            final OperationNodeTypeImplCandidate provCandidate = this.provCandidates.get(this.selectedCandidateSet);
             final Map<String, Integer> order = new HashMap<>();
             // check for index of prov candidates
             for (final String opName : operationNames) {
@@ -493,7 +497,7 @@ public class OperationChain {
                                                 final BPELScopePhaseType phase) {
         int checkCount = 0;
         if (!this.provCandidates.isEmpty()) {
-            final OperationNodeTypeImplCandidate provCandidate = this.provCandidates.get(0);
+            final OperationNodeTypeImplCandidate provCandidate = this.provCandidates.get(this.selectedCandidateSet);
             final Map<String, Integer> order = new HashMap<>();
             // check for index of prov candidates
             for (final String opName : operationNames) {

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/PolicyAwareBPELBuildProcessBuilder.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/PolicyAwareBPELBuildProcessBuilder.java
@@ -282,7 +282,7 @@ public class PolicyAwareBPELBuildProcessBuilder extends AbstractBuildPlanBuilder
                     if (plugin == null) {
                         PolicyAwareBPELBuildProcessBuilder.LOG.debug("Handling NodeTemplate {} with ProvisioningChain",
                                                                      nodeTemplate.getId());
-                        final OperationChain chain = BPELScopeBuilder.createOperationChain(nodeTemplate);
+                        final OperationChain chain = BPELScopeBuilder.createOperationChain(nodeTemplate, this.opNames);
                         if (chain == null) {
                             PolicyAwareBPELBuildProcessBuilder.LOG.warn("Couldn't create ProvisioningChain for NodeTemplate {}",
                                                                         nodeTemplate.getId());
@@ -312,7 +312,7 @@ public class PolicyAwareBPELBuildProcessBuilder extends AbstractBuildPlanBuilder
                     if (policyPlugin == null) {
                         PolicyAwareBPELBuildProcessBuilder.LOG.debug("Handling NodeTemplate {} with ProvisioningChain",
                                                                      nodeTemplate.getId());
-                        final OperationChain chain = BPELScopeBuilder.createOperationChain(nodeTemplate);
+                        final OperationChain chain = BPELScopeBuilder.createOperationChain(nodeTemplate, this.opNames);
                         if (chain == null) {
                             PolicyAwareBPELBuildProcessBuilder.LOG.warn("Couldn't create ProvisioningChain for NodeTemplate {}",
                                                                         nodeTemplate.getId());


### PR DESCRIPTION
#### Short Description
This resolves the issue of randomly selecting a NodeTypeImplementation, if there are multiple ones for one NodeType.

#### Proposed Changes
<!-- List all changes proposed in this pull request -->
Now, the first NodeTypeImplementation which implements the required interface(s) is selected.

