### PR TITLE
fixes bug in ToscaEngineService which returned input parameters instead of output parameters

### DIFF
--- a/org.opentosca.container.core/src/org/opentosca/container/core/engine/impl/ToscaEngineServiceImpl.java
+++ b/org.opentosca.container.core/src/org/opentosca/container/core/engine/impl/ToscaEngineServiceImpl.java
@@ -231,7 +231,7 @@ public class ToscaEngineServiceImpl implements IToscaEngineService {
             getOperationForType(csarID, typeID, interfaceName, operationName, outputParamListDefined);
 
         // check if parameters are defined
-        return operation.map((op) -> !op.getInputParameters().getInputParameter().isEmpty()).orElse(false);
+        return operation.map((op) -> !op.getOutputParameters().getOutputParameter().isEmpty()).orElse(false);
     }
 
     @Override
@@ -266,7 +266,7 @@ public class ToscaEngineServiceImpl implements IToscaEngineService {
 
         // parse parameters to Node
         return operation.map((op) -> ServiceHandler.xmlSerializerService.getXmlSerializer()
-                                                                        .marshalToNode(op.getInputParameters()))
+                                                                        .marshalToNode(op.getOutputParameters()))
                         .orElse(null);
     }
 

--- a/org.opentosca.container.core/src/org/opentosca/container/core/engine/impl/ToscaEngineServiceImpl.java
+++ b/org.opentosca.container.core/src/org/opentosca/container/core/engine/impl/ToscaEngineServiceImpl.java
@@ -257,12 +257,12 @@ public class ToscaEngineServiceImpl implements IToscaEngineService {
                                                     final String operationName) {
 
         // only use operation which have a output parameter list defined
-        final Predicate<TOperation> inputParamListDefined =
+        final Predicate<TOperation> outputParamListDefined =
             (op) -> op.getOutputParameters() != null && op.getOutputParameters().getOutputParameter() != null;
 
         // get the defined operation if available
         final Optional<TOperation> operation =
-            getOperationForType(csarID, typeID, interfaceName, operationName, inputParamListDefined);
+            getOperationForType(csarID, typeID, interfaceName, operationName, outputParamListDefined);
 
         // parse parameters to Node
         return operation.map((op) -> ServiceHandler.xmlSerializerService.getXmlSerializer()


### PR DESCRIPTION
Signed-off-by: Kálmán Képes <kalman.kepes@iaas.uni-stuttgart.de>

#### Short Description
Because of new features there was a bug in the Tosca Engine returning input parameters instead of output parameters this PR fixes this
