### PR TITLE
Expose service template (instance) properties

### DIFF
--- a/org.opentosca.container.api/src/org/opentosca/container/api/controller/ServiceTemplateInstanceController.java
+++ b/org.opentosca.container.api/src/org/opentosca/container/api/controller/ServiceTemplateInstanceController.java
@@ -237,6 +237,15 @@ public class ServiceTemplateInstanceController {
         }
     }
 
+    @GET
+    @Path("/{id}/properties")
+    @Produces({MediaType.APPLICATION_JSON})
+    @ApiOperation(value = "Gets the properties of a service template instance", response = Map.class)
+    public Map<String, String> getServiceTemplateInstancePropertiesAsJSON(@PathParam("id") final Long id) {
+        final ServiceTemplateInstance serviceTemplateInstance = this.instanceService.getServiceTemplateInstance(id);
+        return serviceTemplateInstance.getPropertiesAsMap();
+    }
+
     @PUT
     @Path("/{id}/properties")
     @Consumes({MediaType.APPLICATION_XML})

--- a/org.opentosca.container.api/src/org/opentosca/container/api/dto/boundarydefinitions/PropertiesDTO.java
+++ b/org.opentosca.container.api/src/org/opentosca/container/api/dto/boundarydefinitions/PropertiesDTO.java
@@ -4,12 +4,12 @@ import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyElement;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.opentosca.container.api.dto.ResourceSupport;
-import org.opentosca.container.core.tosca.model.TPropertyMapping;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.collect.Lists;
@@ -21,13 +21,20 @@ import io.swagger.annotations.ApiModelProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PropertiesDTO extends ResourceSupport {
 
-    @XmlElement(name = "XmlFragment")
-    private String xmlFragment;
+    /**
+     * Represents the xml fragment contained in BoundaryDefinitions.Properties which is supposed to
+     * describe global ST properties.
+     */
+    @XmlAnyElement(lax = true)
+    private Object xmlFragment;
 
-
+    /**
+     * Represents the mapping of the ST properties to values derived from ST sub-elements, e.g.,
+     * NodeTemplates.
+     */
     @XmlElement(name = "PropertyMapping")
     @XmlElementWrapper(name = "PropertyMappings")
-    private List<TPropertyMapping> propertyMappings = Lists.newArrayList();
+    private List<PropertyMappingDTO> propertyMappings = Lists.newArrayList();
 
 
     public PropertiesDTO() {
@@ -35,20 +42,20 @@ public class PropertiesDTO extends ResourceSupport {
     }
 
     @ApiModelProperty(name = "xml_fragment")
-    public String getXmlFragment() {
+    public Object getXmlFragment() {
         return this.xmlFragment;
     }
 
-    public void setXmlFragment(final String xmlFragment) {
+    public void setXmlFragment(final Object xmlFragment) {
         this.xmlFragment = xmlFragment;
     }
 
     @ApiModelProperty(name = "property_mappings")
-    public List<TPropertyMapping> getPropertyMappings() {
+    public List<PropertyMappingDTO> getPropertyMappings() {
         return this.propertyMappings;
     }
 
-    public void setPropertyMappings(final List<TPropertyMapping> propertyMappings) {
+    public void setPropertyMappings(final List<PropertyMappingDTO> propertyMappings) {
         this.propertyMappings = propertyMappings;
     }
 }

--- a/org.opentosca.container.api/src/org/opentosca/container/api/dto/boundarydefinitions/PropertyMappingDTO.java
+++ b/org.opentosca.container.api/src/org/opentosca/container/api/dto/boundarydefinitions/PropertyMappingDTO.java
@@ -52,7 +52,4 @@ public class PropertyMappingDTO {
     public void setTargetPropertyRef(final String targetPropertyRef) {
         this.targetPropertyRef = targetPropertyRef;
     }
-
-
-
 }

--- a/org.opentosca.container.api/src/org/opentosca/container/api/dto/boundarydefinitions/PropertyMappingDTO.java
+++ b/org.opentosca.container.api/src/org/opentosca/container/api/dto/boundarydefinitions/PropertyMappingDTO.java
@@ -1,0 +1,58 @@
+package org.opentosca.container.api.dto.boundarydefinitions;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import io.swagger.annotations.ApiModelProperty;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name = "PropertyMapping")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PropertyMappingDTO {
+    @XmlElement(name = "serviceTemplatePropertyRef")
+    private String serviceTemplatePropertyRef;
+
+    @XmlElement(name = "targetObjectRef")
+    private String targetObjectRef;
+
+    @XmlElement(name = "targetPropertyRef")
+    private String targetPropertyRef;
+
+    public PropertyMappingDTO() {
+
+    }
+
+    @ApiModelProperty(name = "service_template_property_ref")
+    public String getServiceTemplatePropertyRef() {
+        return this.serviceTemplatePropertyRef;
+    }
+
+    public void setServiceTemplatePropertyRef(final String serviceTemplatePropertyRef) {
+        this.serviceTemplatePropertyRef = serviceTemplatePropertyRef;
+    }
+
+    @ApiModelProperty(name = "target_object_ref")
+    public String getTargetObjectRef() {
+        return this.targetObjectRef;
+    }
+
+    public void setTargetObjectRef(final String targetObjectRef) {
+        this.targetObjectRef = targetObjectRef;
+    }
+
+    @ApiModelProperty(name = "target_property_ref")
+    public String getTargetPropertyRef() {
+        return this.targetPropertyRef;
+    }
+
+    public void setTargetPropertyRef(final String targetPropertyRef) {
+        this.targetPropertyRef = targetPropertyRef;
+    }
+
+
+
+}

--- a/org.opentosca.container.core/src/org/opentosca/container/core/engine/IToscaReferenceMapper.java
+++ b/org.opentosca.container.core/src/org/opentosca/container/core/engine/IToscaReferenceMapper.java
@@ -304,6 +304,8 @@ public interface IToscaReferenceMapper {
 
     public String getServiceTemplateBoundsPropertiesContent(CSARID csarID, QName serviceTemplateID);
 
+    public Object getServiceTemplateBoundsPropertiesXMLFragment(CSARID csarID, QName serviceTemplateID);
+
     public PropertyMappings getServiceTemplateBoundsPropertyMappings(CSARID csarID, QName serviceTemplateID);
 
     public List<String> getServiceTemplateBoundsPropertiesContent(CSARID csarID);

--- a/org.opentosca.container.core/src/org/opentosca/container/core/engine/impl/ToscaReferenceMapper.java
+++ b/org.opentosca.container.core/src/org/opentosca/container/core/engine/impl/ToscaReferenceMapper.java
@@ -1273,12 +1273,11 @@ public class ToscaReferenceMapper implements IToscaReferenceMapper {
 
     @Override
     public Object getServiceTemplateBoundsPropertiesXMLFragment(final CSARID csarID, final QName serviceTemplateID) {
-
         final String content = this.getServiceTemplateBoundsPropertiesContent(csarID, serviceTemplateID);
         final Object result = JAXB.unmarshal(new StringReader(content), TBoundaryDefinitions.Properties.class);
         final TBoundaryDefinitions.Properties properties = (Properties) result;
-        return properties.getAny();
 
+        return properties.getAny();
     }
 
     @Override

--- a/org.opentosca.container.core/src/org/opentosca/container/core/engine/impl/ToscaReferenceMapper.java
+++ b/org.opentosca.container.core/src/org/opentosca/container/core/engine/impl/ToscaReferenceMapper.java
@@ -1,5 +1,6 @@
 package org.opentosca.container.core.engine.impl;
 
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -7,6 +8,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.xml.bind.JAXB;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
@@ -27,6 +29,7 @@ import org.opentosca.container.core.model.csar.id.CSARID;
 import org.opentosca.container.core.tosca.extension.PlanTypes;
 import org.opentosca.container.core.tosca.model.TBoundaryDefinitions;
 import org.opentosca.container.core.tosca.model.TBoundaryDefinitions.Policies;
+import org.opentosca.container.core.tosca.model.TBoundaryDefinitions.Properties;
 import org.opentosca.container.core.tosca.model.TBoundaryDefinitions.Properties.PropertyMappings;
 import org.opentosca.container.core.tosca.model.TDefinitions;
 import org.opentosca.container.core.tosca.model.TExportedInterface;
@@ -1266,6 +1269,16 @@ public class ToscaReferenceMapper implements IToscaReferenceMapper {
             return properties.get(serviceTemplateID);
         }
         return null;
+    }
+
+    @Override
+    public Object getServiceTemplateBoundsPropertiesXMLFragment(final CSARID csarID, final QName serviceTemplateID) {
+
+        final String content = this.getServiceTemplateBoundsPropertiesContent(csarID, serviceTemplateID);
+        final Object result = JAXB.unmarshal(new StringReader(content), TBoundaryDefinitions.Properties.class);
+        final TBoundaryDefinitions.Properties properties = (Properties) result;
+        return properties.getAny();
+
     }
 
     @Override

--- a/org.opentosca.container.product/config.ini
+++ b/org.opentosca.container.product/config.ini
@@ -1,6 +1,6 @@
 # Container Configuration
 # Your external IP address, e.g. 129.69.214.56
-org.opentosca.container.hostname=129.69.214.56
+org.opentosca.container.hostname=129.69.214.42
 org.opentosca.container.port=1337
 
 # IA Engine Configuration (endpoint and credentials)

--- a/org.opentosca.container.product/config.ini
+++ b/org.opentosca.container.product/config.ini
@@ -1,6 +1,6 @@
 # Container Configuration
 # Your external IP address, e.g. 129.69.214.56
-org.opentosca.container.hostname=129.69.214.42
+org.opentosca.container.hostname=129.69.214.56
 org.opentosca.container.port=1337
 
 # IA Engine Configuration (endpoint and credentials)


### PR DESCRIPTION
#### Short Description
Provide access to `BoundaryDefinition` properties and Service Template Instance properties in JSON format via the API, and ensure the TOSCA standard is observed.

#### Proposed Changes
<!-- List all changes proposed in this pull request -->

  * Ensure that the xml fragment returned by `PropertiesDTO` refers only to the section of the properties before `PropertyMappings` (page 85 of [TOSCA 1.0 Standard](http://docs.oasis-open.org/tosca/TOSCA/v1.0/os/TOSCA-v1.0-os.pdf))
  * Provide access to Service Template Instance properties in JSON format via the `ServiceTemplateInstanceController` as REST endpoint. This endpoint is meant to be consumed by the [container-client]{https://github.com/OpenTOSCA/container-client}


**Related to**: #
[issue 13](https://github.com/OpenTOSCA/container-client/issues/13)
