### PR TITLE
Add ability to evaluate property mappings when using the JSON endpoint

### DIFF
--- a/org.opentosca.container.api/src/org/opentosca/container/api/controller/ServiceTemplateInstanceController.java
+++ b/org.opentosca.container.api/src/org/opentosca/container/api/controller/ServiceTemplateInstanceController.java
@@ -254,8 +254,9 @@ public class ServiceTemplateInstanceController {
     @Produces({MediaType.APPLICATION_XML})
     @ApiOperation(hidden = true, value = "")
     public Response getServiceTemplateInstanceProperties(@PathParam("id") final Long id) {
-        final Document properties = this.instanceService.evaluateServiceTemplateInstanceProperties(id);
-        // final Document properties = this.instanceService.getServiceTemplateInstanceProperties(id);
+        final ServiceTemplateInstance instance = this.instanceService.getServiceTemplateInstance(id, true);
+        final Document properties = instance.getPropertiesAsDocument();
+
         if (properties == null) {
             return Response.noContent().build();
         } else {
@@ -268,7 +269,8 @@ public class ServiceTemplateInstanceController {
     @Produces({MediaType.APPLICATION_JSON})
     @ApiOperation(value = "Gets the properties of a service template instance", response = Map.class)
     public Map<String, String> getServiceTemplateInstancePropertiesAsJSON(@PathParam("id") final Long id) {
-        final ServiceTemplateInstance serviceTemplateInstance = this.instanceService.getServiceTemplateInstance(id);
+        final ServiceTemplateInstance serviceTemplateInstance =
+            this.instanceService.getServiceTemplateInstance(id, true);
         return serviceTemplateInstance.getPropertiesAsMap();
     }
 
@@ -304,7 +306,7 @@ public class ServiceTemplateInstanceController {
                                                     final String templateId) throws NotFoundException {
         // We only need to check that the instance belongs to the template, the rest is
         // guaranteed while this is a sub-resource
-        final ServiceTemplateInstance instance = this.instanceService.getServiceTemplateInstance(instanceId);
+        final ServiceTemplateInstance instance = this.instanceService.getServiceTemplateInstance(instanceId, false);
 
         if (!instance.getTemplateId().equals(QName.valueOf(templateId))) {
             logger.info("Service template instance <{}> could not be found", instanceId);

--- a/org.opentosca.container.api/src/org/opentosca/container/api/controller/SituationsController.java
+++ b/org.opentosca.container.api/src/org/opentosca/container/api/controller/SituationsController.java
@@ -140,7 +140,8 @@ public class SituationsController {
 
         ServiceTemplateInstance serviceInstance;
         try {
-            serviceInstance = this.instanceService.getServiceTemplateInstance(situationTrigger.getServiceInstanceId());
+            serviceInstance =
+                this.instanceService.getServiceTemplateInstance(situationTrigger.getServiceInstanceId(), false);
         }
         catch (final NotFoundException e) {
             serviceInstance = null;

--- a/org.opentosca.container.api/src/org/opentosca/container/api/service/InstanceService.java
+++ b/org.opentosca.container.api/src/org/opentosca/container/api/service/InstanceService.java
@@ -129,12 +129,19 @@ public class InstanceService {
                                                      .findFirst().get();
     }
 
-    public ServiceTemplateInstance getServiceTemplateInstance(final Long id) {
+    public ServiceTemplateInstance getServiceTemplateInstance(final Long id, final boolean evaluatePropertyMappings) {
         logger.debug("Requesting service template instance <{}>...", id);
         final Optional<ServiceTemplateInstance> instance = this.serviceTemplateInstanceRepository.find(id);
 
         if (instance.isPresent()) {
-            return instance.get();
+            final ServiceTemplateInstance result = instance.get();
+
+            if (evaluatePropertyMappings) {
+                final PropertyMappingsHelper helper = new PropertyMappingsHelper(this);
+                helper.evaluatePropertyMappings(result);
+            }
+
+            return result;
         }
 
         logger.debug("Service Template Instance <" + id + "> not found.");
@@ -142,7 +149,7 @@ public class InstanceService {
     }
 
     public ServiceTemplateInstanceState getServiceTemplateInstanceState(final Long id) {
-        final ServiceTemplateInstance service = getServiceTemplateInstance(id);
+        final ServiceTemplateInstance service = getServiceTemplateInstance(id, false);
 
         return service.getState();
     }
@@ -161,28 +168,15 @@ public class InstanceService {
             throw new IllegalArgumentException(msg, e);
         }
 
-        final ServiceTemplateInstance service = getServiceTemplateInstance(id);
+        final ServiceTemplateInstance service = getServiceTemplateInstance(id, false);
         service.setState(newState);
         this.serviceTemplateInstanceRepository.update(service);
     }
 
-    /**
-     * Evaluates the property mappings of a boundary definition's properties against the xml fragment
-     * representing these properties and uses node template instances for this purpose.
-     *
-     * @param serviceTemplateInstanceId the id of the service template instance whose property mappings
-     *        we want to evaluate
-     * @return the xml fragment representing the properties after property mappings are evaluated
-     * @throws NotFoundException thrown when the id does not correspond to a service template instance
-     */
-    public Document evaluateServiceTemplateInstanceProperties(final Long id) throws NotFoundException {
-        final PropertyMappingsHelper helper = new PropertyMappingsHelper(this);
 
-        return helper.evaluatePropertyMappings(id);
-    }
 
     public Document getServiceTemplateInstanceRawProperties(final Long id) throws NotFoundException {
-        final ServiceTemplateInstance service = getServiceTemplateInstance(id);
+        final ServiceTemplateInstance service = getServiceTemplateInstance(id, false);
         final Optional<ServiceTemplateInstanceProperty> firstProp = service.getProperties().stream().findFirst();
 
         if (firstProp.isPresent()) {
@@ -197,7 +191,7 @@ public class InstanceService {
 
     public void setServiceTemplateInstanceProperties(final Long id,
                                                      final Document properties) throws ReflectiveOperationException {
-        final ServiceTemplateInstance service = getServiceTemplateInstance(id);
+        final ServiceTemplateInstance service = getServiceTemplateInstance(id, false);
 
         try {
             final ServiceTemplateInstanceProperty property =
@@ -215,8 +209,8 @@ public class InstanceService {
     }
 
     public void deleteServiceTemplateInstance(final Long instanceId) {
-        final ServiceTemplateInstance instance = getServiceTemplateInstance(instanceId); // throws exception if not
-                                                                                         // found
+        // throws exception if not found
+        final ServiceTemplateInstance instance = getServiceTemplateInstance(instanceId, false);
         this.serviceTemplateInstanceRepository.remove(instance);
     }
 
@@ -437,7 +431,8 @@ public class InstanceService {
         // Type
         newInstance.setTemplateType(QName.valueOf(dto.getNodeType()));
         // ServiceTemplateInstance
-        final ServiceTemplateInstance serviceTemplateInstance = getServiceTemplateInstance(serviceTemplateInstanceId);
+        final ServiceTemplateInstance serviceTemplateInstance =
+            getServiceTemplateInstance(serviceTemplateInstanceId, false);
 
         if (!serviceTemplateInstance.getTemplateId().equals(serviceTemplateQName)) {
             final String msg =

--- a/org.opentosca.container.api/src/org/opentosca/container/api/service/PropertyMappingsHelper.java
+++ b/org.opentosca.container.api/src/org/opentosca/container/api/service/PropertyMappingsHelper.java
@@ -36,33 +36,25 @@ public class PropertyMappingsHelper {
 
     /**
      * Evaluates the property mappings of a boundary definition's properties against the xml fragment
-     * representing these properties and uses node template instances for this purpose.
+     * representing these properties and uses node template instances for this purpose. The resulting
+     * service template instance is not automatically persisted in the DB.
      *
-     * @param serviceTemplateInstanceId the id of the service template instance whose property mappings
-     *        we want to evaluate
-     * @return the xml fragment representing the properties after property mappings are evaluated
-     * @throws NotFoundException thrown when the id does not correspond to a service template instance
+     * @param serviceTemplateInstance the the service template instance whose property mappings we want
+     *        to evaluate
      */
-    public Document evaluatePropertyMappings(final Long serviceTemplateInstanceId) throws NotFoundException {
-        final ServiceTemplateInstance serviceInstance =
-            this.instanceService.getServiceTemplateInstance(serviceTemplateInstanceId);
-
+    public void evaluatePropertyMappings(final ServiceTemplateInstance serviceInstance) throws NotFoundException {
         if (serviceInstance == null) {
-            final String msg = String.format("Failed to retrieve ServiceInstance: '%s'", serviceInstance);
-            throw new NotFoundException(msg);
+            return;
         }
 
-        final Document propertiesAsXML =
-            this.instanceService.getServiceTemplateInstanceRawProperties(serviceTemplateInstanceId);
+        final Document propertiesAsXML = serviceInstance.getPropertiesAsDocument();
 
         // check if the serviceInstance has properties
         if (propertiesAsXML == null) {
-            return null;
+            return;
         }
 
         updateServiceInstanceProperties(serviceInstance, propertiesAsXML);
-
-        return propertiesAsXML;
     }
 
     private void updateServiceInstanceProperties(final ServiceTemplateInstance serviceInstance,
@@ -145,7 +137,6 @@ public class PropertyMappingsHelper {
         catch (InstantiationException | IllegalAccessException | IllegalArgumentException e) {
             logger.error("Failed to store properties in service template instance object. Reason {}", e.getMessage());
         }
-        // this.siDAO.storeServiceInstance(serviceInstance);
     }
 
     private List<Element> queryElementList(final Element node, final String xpathQuery) {

--- a/org.opentosca.container.core/src/org/opentosca/container/core/next/model/ServiceTemplateInstance.java
+++ b/org.opentosca.container.core/src/org/opentosca/container/core/next/model/ServiceTemplateInstance.java
@@ -17,8 +17,10 @@ import javax.persistence.Table;
 import javax.xml.namespace.QName;
 
 import org.eclipse.persistence.annotations.Convert;
+import org.opentosca.container.core.common.jpa.DocumentConverter;
 import org.opentosca.container.core.model.csar.id.CSARID;
 import org.opentosca.container.core.next.xml.PropertyParser;
+import org.w3c.dom.Document;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -29,154 +31,165 @@ import com.google.common.collect.Sets;
 @Table(name = ServiceTemplateInstance.TABLE_NAME)
 public class ServiceTemplateInstance extends PersistenceObject {
 
-	private static final long serialVersionUID = 6652347924001914320L;
+    private static final long serialVersionUID = 6652347924001914320L;
 
-	public static final String TABLE_NAME = "SERVICE_TEMPLATE_INSTANCE";
+    public static final String TABLE_NAME = "SERVICE_TEMPLATE_INSTANCE";
 
-	@Column(nullable = false)
-	@Enumerated(EnumType.STRING)
-	private ServiceTemplateInstanceState state;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ServiceTemplateInstanceState state;
 
-	@OneToMany(mappedBy = "serviceTemplateInstance")
-	private Collection<PlanInstance> planInstances = Lists.newArrayList();
+    @OneToMany(mappedBy = "serviceTemplateInstance")
+    private Collection<PlanInstance> planInstances = Lists.newArrayList();
 
-	@OneToMany(mappedBy = "serviceTemplateInstance")
-	private Collection<NodeTemplateInstance> nodeTemplateInstances = Lists.newArrayList();
+    @OneToMany(mappedBy = "serviceTemplateInstance")
+    private Collection<NodeTemplateInstance> nodeTemplateInstances = Lists.newArrayList();
 
-	@Convert("CSARIDConverter")
-	@Column(name = "CSAR_ID", nullable = false)
-	private CSARID csarId;
+    @Convert("CSARIDConverter")
+    @Column(name = "CSAR_ID", nullable = false)
+    private CSARID csarId;
 
-	@Convert("QNameConverter")
-	@Column(name = "TEMPLATE_ID", nullable = false)
-	private QName templateId;
-	
-	@Column(name ="CREATION_CORRELATION_ID", nullable = true)
-	private String creationCorrelationId;
+    @Convert("QNameConverter")
+    @Column(name = "TEMPLATE_ID", nullable = false)
+    private QName templateId;
 
-	@OrderBy("createdAt DESC")
-	@OneToMany(mappedBy = "serviceTemplateInstance", cascade = { CascadeType.ALL })
-	@JsonIgnore
-	private Set<ServiceTemplateInstanceProperty> properties = Sets.newHashSet();
+    @Column(name = "CREATION_CORRELATION_ID", nullable = true)
+    private String creationCorrelationId;
 
-	@OrderBy("createdAt DESC")
-	@OneToMany(mappedBy = "serviceTemplateInstance")
-	@JsonIgnore
-	private List<DeploymentTest> deploymentTests = Lists.newArrayList();
+    @OrderBy("createdAt DESC")
+    @OneToMany(mappedBy = "serviceTemplateInstance", cascade = {CascadeType.ALL})
+    @JsonIgnore
+    private Set<ServiceTemplateInstanceProperty> properties = Sets.newHashSet();
 
-	public ServiceTemplateInstance() {
-	}
+    @OrderBy("createdAt DESC")
+    @OneToMany(mappedBy = "serviceTemplateInstance")
+    @JsonIgnore
+    private List<DeploymentTest> deploymentTests = Lists.newArrayList();
 
-	public ServiceTemplateInstanceState getState() {
-		return this.state;
-	}
+    public ServiceTemplateInstance() {}
 
-	public void setState(final ServiceTemplateInstanceState state) {
-		this.state = state;
-	}
+    public ServiceTemplateInstanceState getState() {
+        return this.state;
+    }
 
-	public Collection<PlanInstance> getPlanInstances() {
-		return this.planInstances;
-	}
+    public void setState(final ServiceTemplateInstanceState state) {
+        this.state = state;
+    }
 
-	public void setPlanInstances(final Collection<PlanInstance> planInstances) {
-		this.planInstances = planInstances;
-	}
+    public Collection<PlanInstance> getPlanInstances() {
+        return this.planInstances;
+    }
 
-	public void addPlanInstance(final PlanInstance planInstance) {
-		if (planInstance.getType().equals(PlanType.BUILD)) {
-			this.planInstances.add(planInstance);
-			if (planInstance.getServiceTemplateInstance() != this) {
-				planInstance.setServiceTemplateInstance(this);
-			}
-		}
-	}
+    public void setPlanInstances(final Collection<PlanInstance> planInstances) {
+        this.planInstances = planInstances;
+    }
 
-	public Collection<NodeTemplateInstance> getNodeTemplateInstances() {
-		return this.nodeTemplateInstances;
-	}
+    public void addPlanInstance(final PlanInstance planInstance) {
+        if (planInstance.getType().equals(PlanType.BUILD)) {
+            this.planInstances.add(planInstance);
+            if (planInstance.getServiceTemplateInstance() != this) {
+                planInstance.setServiceTemplateInstance(this);
+            }
+        }
+    }
 
-	public void setNodeTemplateInstances(final Collection<NodeTemplateInstance> nodeTemplateInstances) {
-		this.nodeTemplateInstances = nodeTemplateInstances;
-	}
+    public Collection<NodeTemplateInstance> getNodeTemplateInstances() {
+        return this.nodeTemplateInstances;
+    }
 
-	public void addNodeTemplateInstance(final NodeTemplateInstance nodeTemplateInstance) {
-		this.nodeTemplateInstances.add(nodeTemplateInstance);
-		if (nodeTemplateInstance.getServiceTemplateInstance() != this) {
-			nodeTemplateInstance.setServiceTemplateInstance(this);
-		}
-	}
+    public void setNodeTemplateInstances(final Collection<NodeTemplateInstance> nodeTemplateInstances) {
+        this.nodeTemplateInstances = nodeTemplateInstances;
+    }
 
-	public CSARID getCsarId() {
-		return this.csarId;
-	}
+    public void addNodeTemplateInstance(final NodeTemplateInstance nodeTemplateInstance) {
+        this.nodeTemplateInstances.add(nodeTemplateInstance);
+        if (nodeTemplateInstance.getServiceTemplateInstance() != this) {
+            nodeTemplateInstance.setServiceTemplateInstance(this);
+        }
+    }
 
-	public void setCsarId(final CSARID csarId) {
-		this.csarId = csarId;
-	}
+    public CSARID getCsarId() {
+        return this.csarId;
+    }
 
-	public QName getTemplateId() {
-		return this.templateId;
-	}
+    public void setCsarId(final CSARID csarId) {
+        this.csarId = csarId;
+    }
 
-	public void setTemplateId(final QName templateId) {
-		this.templateId = templateId;
-	}
-	
-	public String getCreationCorrelationId() {
-		return this.creationCorrelationId;
-	}
-	
-	public void setCreationCorrelationId(String creationCorrelationId) {
-		this.creationCorrelationId = creationCorrelationId;
-	}
+    public QName getTemplateId() {
+        return this.templateId;
+    }
 
-	public Collection<ServiceTemplateInstanceProperty> getProperties() {
-		return this.properties;
-	}
+    public void setTemplateId(final QName templateId) {
+        this.templateId = templateId;
+    }
 
-	public void setProperties(final Set<ServiceTemplateInstanceProperty> properties) {
-		this.properties = properties;
-	}
+    public String getCreationCorrelationId() {
+        return this.creationCorrelationId;
+    }
 
-	public void addProperty(final ServiceTemplateInstanceProperty property) {
-		if (!this.properties.add(property)) {
-			this.properties.remove(property);
-			this.properties.add(property);
-		}
-		if (property.getServiceTemplateInstance() != this) {
-			property.setServiceTemplateInstance(this);
-		}
-	}
+    public void setCreationCorrelationId(final String creationCorrelationId) {
+        this.creationCorrelationId = creationCorrelationId;
+    }
 
-	/*
-	 * Currently, the plan writes all properties as one XML document into the
-	 * database. Therefore, we parse this XML and return a Map<String, String>.
-	 */
-	@JsonProperty("properties")
-	public Map<String, String> getPropertiesAsMap() {
-		final PropertyParser parser = new PropertyParser();
-		final ServiceTemplateInstanceProperty prop = getProperties().stream()
-				.filter(p -> p.getType().equalsIgnoreCase("xml")).collect(Collectors.reducing((a, b) -> null))
-				.orElse(null);
-		if (prop != null) {
-			return parser.parse(prop.getValue());
-		}
-		return null;
-	}
+    public Collection<ServiceTemplateInstanceProperty> getProperties() {
+        return this.properties;
+    }
 
-	public List<DeploymentTest> getDeploymentTests() {
-		return this.deploymentTests;
-	}
+    public void setProperties(final Set<ServiceTemplateInstanceProperty> properties) {
+        this.properties = properties;
+    }
 
-	public void setDeploymentTests(final List<DeploymentTest> deploymentTests) {
-		this.deploymentTests = deploymentTests;
-	}
+    public void addProperty(final ServiceTemplateInstanceProperty property) {
+        if (!this.properties.add(property)) {
+            this.properties.remove(property);
+            this.properties.add(property);
+        }
+        if (property.getServiceTemplateInstance() != this) {
+            property.setServiceTemplateInstance(this);
+        }
+    }
 
-	public void addDeploymentTest(final DeploymentTest deploymentTest) {
-		this.deploymentTests.add(deploymentTest);
-		if (deploymentTest.getServiceTemplateInstance() != this) {
-			deploymentTest.setServiceTemplateInstance(this);
-		}
-	}
+    /*
+     * Currently, the plan writes all properties as one XML document into the database. Therefore, we
+     * parse this XML and return a Map<String, String>.
+     */
+    @JsonProperty("properties")
+    public Map<String, String> getPropertiesAsMap() {
+        final PropertyParser parser = new PropertyParser();
+        final ServiceTemplateInstanceProperty prop =
+            getProperties().stream().filter(p -> p.getType().equalsIgnoreCase("xml"))
+                           .collect(Collectors.reducing((a, b) -> null)).orElse(null);
+        if (prop != null) {
+            return parser.parse(prop.getValue());
+        }
+        return null;
+    }
+
+    public Document getPropertiesAsDocument() {
+        final DocumentConverter converter = new DocumentConverter();
+        final ServiceTemplateInstanceProperty prop =
+            getProperties().stream().filter(p -> p.getType().equalsIgnoreCase("xml"))
+                           .collect(Collectors.reducing((a, b) -> null)).orElse(null);
+        if (prop != null) {
+            return (Document) converter.convertDataValueToObjectValue(prop.getValue(), null);
+        }
+
+        return null;
+    }
+
+    public List<DeploymentTest> getDeploymentTests() {
+        return this.deploymentTests;
+    }
+
+    public void setDeploymentTests(final List<DeploymentTest> deploymentTests) {
+        this.deploymentTests = deploymentTests;
+    }
+
+    public void addDeploymentTest(final DeploymentTest deploymentTest) {
+        this.deploymentTests.add(deploymentTest);
+        if (deploymentTest.getServiceTemplateInstance() != this) {
+            deploymentTest.setServiceTemplateInstance(this);
+        }
+    }
 }


### PR DESCRIPTION
#### Short Description
Evaluate `PropertyMappings` when calling the `...instances/{id}/properties` JSON end point with a GET.

#### Proposed Changes
  * Add an explicit parameter to the `InstanceService.getServiceTemplateInstance` method to indicate whether to evaluate `PropertyMappings` or not
  * Add ability to retrieve `ServiceTemplateInstance` properties as a `Document` object.

**Fixes**: #
https://github.com/OpenTOSCA/container-client/issues/13