### PR TITLE
Set the value of empty parameters to empty string

### DIFF
--- a/org.opentosca.container.core.impl/src/org/opentosca/container/core/impl/plan/PlanInvocationEngine.java
+++ b/org.opentosca.container.core.impl/src/org/opentosca/container/core/impl/plan/PlanInvocationEngine.java
@@ -1,7 +1,6 @@
 package org.opentosca.container.core.impl.plan;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -12,7 +11,6 @@ import java.util.stream.Collectors;
 
 import javax.xml.namespace.QName;
 
-import org.glassfish.jersey.uri.UriComponent;
 import org.opentosca.container.core.common.Settings;
 import org.opentosca.container.core.impl.plan.messages.ResponseParser;
 import org.opentosca.container.core.model.csar.id.CSARID;
@@ -237,11 +235,11 @@ public class PlanInvocationEngine implements IPlanInvocationEngine, EventHandler
         } else {
             eventValues.put("ASYNC", false);
         }
+
         eventValues.put("MESSAGEID", correlationID);
-        
-        eventValues.put("SERVICEINSTANCEID" , serviceTemplateInstanceID);
+        eventValues.put("SERVICEINSTANCEID", serviceTemplateInstanceID);
         eventValues.put("SERVICETEMPLATEID", serviceTemplateId);
-        
+
 
         ServiceProxy.csarInstanceManagement.storePublicPlanToHistory(correlationID, planEvent);
 
@@ -429,6 +427,7 @@ public class PlanInvocationEngine implements IPlanInvocationEngine, EventHandler
                     newParam.setName(temp.getName());
                     newParam.setType(temp.getType());
                     newParam.setRequired(temp.getRequired());
+                    newParam.setValue("");
                     planEvent.getInputParameter().add(newParam);
                 }
             }
@@ -448,7 +447,7 @@ public class PlanInvocationEngine implements IPlanInvocationEngine, EventHandler
             eventValues.put("PLANID", planEvent.getPlanID());
             eventValues.put("PLANLANGUAGE", planEvent.getPlanLanguage());
             eventValues.put("OPERATIONNAME", planEvent.getOperationName());
-            eventValues.put("INPUTS", this.transform(planEvent.getInputParameter()));
+            eventValues.put("INPUTS", transform(planEvent.getInputParameter()));
             eventValues.put("SERVICEINSTANCEID", serviceTemplateInstanceID);
 
             this.LOG.debug("complete the list of parameters {}", givenPlan.getId());
@@ -492,7 +491,7 @@ public class PlanInvocationEngine implements IPlanInvocationEngine, EventHandler
         }
     }
 
-    private Map<String, String> transform(List<TParameterDTO> params) {
+    private Map<String, String> transform(final List<TParameterDTO> params) {
         return params.stream().collect(Collectors.toMap(TParameterDTO::getName, TParameterDTO::getValue));
     }
 
@@ -506,7 +505,7 @@ public class PlanInvocationEngine implements IPlanInvocationEngine, EventHandler
 
 
     public Map<String, String> createRequest(final CSARID csarID, final QName serviceTemplateID,
-                                             Long serviceTemplateInstanceId, final QName planInputMessageID,
+                                             final Long serviceTemplateInstanceId, final QName planInputMessageID,
                                              final List<TParameterDTO> inputParameter,
                                              final String correlationID) throws UnsupportedEncodingException {
 


### PR DESCRIPTION
#### Short Description
When invoking a plan via the REST API, non-user-provided parameters should not be expected to be provided by the user!
Before this pull request, these parameters were added by container code BUT with a `null` value. This caused an exception.

#### Proposed Changes
<!-- List all changes proposed in this pull request -->

  * The value of parameters not provided via the API are set to an empty `string` instead of `null`

**Fixes**: https://github.com/OpenTOSCA/container-client/issues/15 
