### PR TITLE
Fixes issue with Termination Plan

### DIFF
--- a/org.opentosca.container.api/src/org/opentosca/container/api/controller/NodeTemplateInstanceController.java
+++ b/org.opentosca.container.api/src/org/opentosca/container/api/controller/NodeTemplateInstanceController.java
@@ -68,7 +68,7 @@ public class NodeTemplateInstanceController {
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @ApiOperation(value = "Get all instances of a node template", response = NodeTemplateInstanceListDTO.class)
     public Response getNodeTemplateInstances(@QueryParam(value = "state") final List<NodeTemplateInstanceState> states,
-                                             @QueryParam(value = "source") final List<Long> relationIds) {
+                                             @QueryParam(value = "source") final List<Long> relationIds, @QueryParam(value="serviceInstanceId") final Long serviceInstanceId) {
         final QName nodeTemplateQName =
             new QName(QName.valueOf(this.servicetemplate).getNamespaceURI(), this.nodetemplate);
         final Collection<NodeTemplateInstance> nodeInstances =
@@ -93,6 +93,10 @@ public class NodeTemplateInstanceController {
             }
             
             if(!i.getServiceTemplateInstance().getTemplateId().toString().equals(this.servicetemplate)) {
+                continue;
+            }
+            
+            if(serviceInstanceId != null && !i.getServiceTemplateInstance().getId().equals(serviceInstanceId)) {
                 continue;
             }
 

--- a/org.opentosca.container.api/src/org/opentosca/container/api/controller/RelationshipTemplateInstanceController.java
+++ b/org.opentosca.container.api/src/org/opentosca/container/api/controller/RelationshipTemplateInstanceController.java
@@ -67,7 +67,7 @@ public class RelationshipTemplateInstanceController {
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @ApiOperation(value = "Get all relationship template instances",
                   response = RelationshipTemplateInstanceListDTO.class)
-    public Response getRelationshipTemplateInstances(@QueryParam(value = "state") final List<RelationshipTemplateInstanceState> states,@QueryParam(value = "target") final Long targetNodeInstanceId) {
+    public Response getRelationshipTemplateInstances(@QueryParam(value = "state") final List<RelationshipTemplateInstanceState> states,@QueryParam(value = "target") final Long targetNodeInstanceId, @QueryParam(value="serviceInstanceId") final Long serviceInstanceId) {
         final QName relationshipTemplateQName =
             new QName(QName.valueOf(this.servicetemplate).getNamespaceURI(), this.relationshiptemplate);
         final Collection<RelationshipTemplateInstance> relationshipInstances =
@@ -90,6 +90,11 @@ public class RelationshipTemplateInstanceController {
                 // skip this instance if the target id doesn't match
                 continue;
             }
+            
+            if(serviceInstanceId != null && !i.getServiceTemplateInstance().getId().equals(serviceInstanceId)) {
+                continue;
+            }
+            
             final RelationshipTemplateInstanceDTO dto = RelationshipTemplateInstanceDTO.Converter.convert(i);
             dto.add(UriUtil.generateSubResourceLink(this.uriInfo, dto.getId().toString(), false, "self"));
 

--- a/org.opentosca.container.api/src/org/opentosca/container/api/dto/request/CreateRelationshipTemplateInstanceRequest.java
+++ b/org.opentosca.container.api/src/org/opentosca/container/api/dto/request/CreateRelationshipTemplateInstanceRequest.java
@@ -11,12 +11,24 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CreateRelationshipTemplateInstanceRequest {
+    
+    @XmlAttribute(name = "service-instance-id")
+    private Long serviceInstanceId;
+    
     @XmlAttribute(name = "source-instance-id")
     private Long sourceNodeTemplateInstanceId;
 
     @XmlAttribute(name = "target-instance-id")
     private Long targetNodeTemplateInstanceId;
 
+    public Long getServiceInstanceId() {
+        return this.serviceInstanceId;
+    }
+    
+    public void setServiceInstanceId(final Long serviceInstanceId) {
+        this.serviceInstanceId = serviceInstanceId;
+    }
+    
     public Long getSourceNodeTemplateInstanceId() {
         return this.sourceNodeTemplateInstanceId;
     }

--- a/org.opentosca.container.api/src/org/opentosca/container/api/service/InstanceService.java
+++ b/org.opentosca.container.api/src/org/opentosca/container/api/service/InstanceService.java
@@ -619,7 +619,8 @@ public class InstanceService {
         // Source node instance
         newInstance.setSource(getNodeTemplateInstance(request.getSourceNodeTemplateInstanceId()));
         // Target node instance
-        newInstance.setTarget(getNodeTemplateInstance(request.getTargetNodeTemplateInstanceId()));
+        newInstance.setTarget(getNodeTemplateInstance(request.getTargetNodeTemplateInstanceId()));        
+        newInstance.setServiceTemplateInstance(this.serviceTemplateInstanceRepository.find(request.getServiceInstanceId()).get());
 
         this.relationshipTemplateInstanceRepository.add(newInstance);
 

--- a/org.opentosca.planbuilder.core.bpel/META-INF/resources/schemas/opentoscaapischema.xsd
+++ b/org.opentosca.planbuilder.core.bpel/META-INF/resources/schemas/opentoscaapischema.xsd
@@ -7,6 +7,7 @@
 	<element name="CreateRelationshipTemplateInstanceRequest" type="tns:TCreateRelationshipTemplateInstanceRequest"/>
 
 	<complexType name="TCreateRelationshipTemplateInstanceRequest">
+		<attribute name="service-instance-id" />
 		<attribute name="source-instance-id" />
 		<attribute name="target-instance-id"/>
 	</complexType>

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/typebasednodehandler/BPELPluginHandler.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/typebasednodehandler/BPELPluginHandler.java
@@ -64,9 +64,10 @@ public class BPELPluginHandler {
         return result;
     }
 
+
     private boolean handleTerminationActivity(final BPELPlanContext context, final BPELScope bpelScope,
                                               final AbstractRelationshipTemplate relationshipTemplate) {
-        boolean result = false;
+        boolean result = true;
 
         // generate code for the termination, e.g., call install, start or create
         // methods
@@ -90,9 +91,10 @@ public class BPELPluginHandler {
         return result;
     }
 
+
     private boolean handleTerminationActivity(final BPELPlanContext context, final BPELScope bpelScope,
                                               final AbstractNodeTemplate nodeTemplate) {
-        boolean result = false;
+        boolean result = true;
 
         // generate code for the termination, e.g., call install, start or create
         // methods

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/typebasedplanbuilder/BPELTerminationProcessBuilder.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/typebasedplanbuilder/BPELTerminationProcessBuilder.java
@@ -112,25 +112,27 @@ public class BPELTerminationProcessBuilder extends AbstractTerminationPlanBuilde
         this.serviceInstanceHandler.addServiceInstanceHandlingFromInput(newTerminationPlan);
         String serviceTemplateURLVarName =
             this.serviceInstanceHandler.getServiceTemplateURLVariableName(newTerminationPlan);
+        
+        String serviceInstanceId = this.serviceInstanceHandler.findServiceInstanceIdVarName(newTerminationPlan);
+        
         this.serviceInstanceHandler.appendInitPropertyVariablesFromServiceInstanceData(newTerminationPlan, propMap,
                                                                                        serviceTemplateURLVarName,
                                                                                        serviceTemplate, "?state=STARTED&amp;state=CREATED&amp;state=CONFIGURED");
 
         // fetch all nodeinstances that are running
         this.instanceVarsHandler.addNodeInstanceFindLogic(newTerminationPlan,
-                                                          "?state=STARTED&amp;state=CREATED&amp;state=CONFIGURED",
+                                                          "?state=STARTED&amp;state=CREATED&amp;state=CONFIGURED&amp;serviceInstanceId=$bpelvar["+serviceInstanceId+"]",
                                                           serviceTemplate);
         this.instanceVarsHandler.addPropertyVariableUpdateBasedOnNodeInstanceID(newTerminationPlan, propMap,
                                                                                 serviceTemplate);
 
-        this.instanceVarsHandler.addRelationInstanceFindLogic(newTerminationPlan, "?state=CREATED&amp;state=INITIAL",
+        this.instanceVarsHandler.addRelationInstanceFindLogic(newTerminationPlan, "?state=CREATED&amp;state=INITIAL&amp;serviceInstanceId=$bpelvar["+serviceInstanceId+"]",
                                                               serviceTemplate);
 
         final List<BPELScope> changedActivities = runPlugins(newTerminationPlan, propMap, csarName);
 
         String serviceInstanceURLVarName =
             this.serviceInstanceHandler.findServiceInstanceUrlVariableName(newTerminationPlan);
-        String serviceInstanceId = this.serviceInstanceHandler.findServiceInstanceIdVarName(newTerminationPlan);
 
 
         this.serviceInstanceHandler.appendSetServiceInstanceState(newTerminationPlan,
@@ -153,13 +155,13 @@ public class BPELTerminationProcessBuilder extends AbstractTerminationPlanBuilde
                     new BPELPlanContext(newTerminationPlan, activ, propMap, newTerminationPlan.getServiceTemplate(),
                         serviceInstanceURLVarName, serviceInstanceId, serviceTemplateURLVarName, csarName);
                 this.instanceVarsHandler.appendCountInstancesLogic(context, activ.getNodeTemplate(),
-                                                                   "?state=STARTED&amp;state=CREATED&amp;state=CONFIGURED");
+                                                                   "?state=STARTED&amp;state=CREATED&amp;state=CONFIGURED&amp;serviceInstanceId=$bpelvar["+serviceInstanceId+"]");
             } else {
                 final BPELPlanContext context =
                     new BPELPlanContext(newTerminationPlan, activ, propMap, newTerminationPlan.getServiceTemplate(),
                         serviceInstanceURLVarName, serviceInstanceId, serviceTemplateURLVarName, csarName);
                 this.instanceVarsHandler.appendCountInstancesLogic(context, activ.getRelationshipTemplate(),
-                                                                   "?state=CREATED&amp;state=INITIAL");
+                                                                   "?state=CREATED&amp;state=INITIAL&amp;serviceInstanceId=$bpelvar["+serviceInstanceId+"]");
             }
         }
 
@@ -212,20 +214,21 @@ public class BPELTerminationProcessBuilder extends AbstractTerminationPlanBuilde
 
         final List<BPELScope> changedActivities = new ArrayList<>();
         for (final BPELScope bpelScope : plan.getTemplateBuildPlans()) {
-            // we handle only nodeTemplates..
+            boolean result = false;
             if (bpelScope.getNodeTemplate() != null) {
-
                 final AbstractNodeTemplate nodeTemplate = bpelScope.getNodeTemplate();
-                // .. that are VM nodeTypes
-                // create context for the templatePlan
                 final BPELPlanContext context = new BPELPlanContext(plan, bpelScope, propMap, plan.getServiceTemplate(),
                     serviceInstanceUrl, serviceInstanceId, serviceTemplateUrl, csarName);
-                this.bpelPluginHandler.handleActivity(context, bpelScope, nodeTemplate);
+                result = this.bpelPluginHandler.handleActivity(context, bpelScope, nodeTemplate);                
             } else {
                 AbstractRelationshipTemplate relationshipTempalte = bpelScope.getRelationshipTemplate();
                 final BPELPlanContext context = new BPELPlanContext(plan, bpelScope, propMap, plan.getServiceTemplate(),
                     serviceInstanceUrl, serviceInstanceId, serviceTemplateUrl, csarName);
-                this.bpelPluginHandler.handleActivity(context, bpelScope, relationshipTempalte);
+                result = this.bpelPluginHandler.handleActivity(context, bpelScope, relationshipTempalte);
+            }
+            
+            if(result) {
+                changedActivities.add(bpelScope);
             }
 
         }

--- a/org.opentosca.planbuilder.postphase.plugin.instancedata/META-INF/resources/BPEL4RESTLightPOST_RelationInstance_InstanceDataAPI.xml
+++ b/org.opentosca.planbuilder.postphase.plugin.instancedata/META-INF/resources/BPEL4RESTLightPOST_RelationInstance_InstanceDataAPI.xml
@@ -6,7 +6,7 @@
 				<bpel:from>
 					<bpel:literal>
 						<api:CreateRelationshipTemplateInstanceRequest
-							xmlns:api="http://opentosca.org/api" source-instance-id="asd"
+							xmlns:api="http://opentosca.org/api" service-instance-id="asd" source-instance-id="asd"
 							target-instance-id="asd" />
 					</bpel:literal>
 				</bpel:from>
@@ -26,6 +26,14 @@
 				</bpel:from>
 				<bpel:to variable="$RequestVarName">
 					<bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0"><![CDATA[$$RequestVarName/@*[local-name()='target-instance-id']]]></bpel:query>
+				</bpel:to>
+			</bpel:copy>
+			<bpel:copy>
+				<bpel:from variable="$serviceInstanceIdVarName">
+					<bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0"><![CDATA[string($$serviceInstanceIdVarName)]]></bpel:query>
+				</bpel:from>
+				<bpel:to variable="$RequestVarName">
+					<bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0"><![CDATA[$$RequestVarName/@*[local-name()='service-instance-id']]]></bpel:query>
 				</bpel:to>
 			</bpel:copy>
 		</bpel:assign>

--- a/org.opentosca.planbuilder.postphase.plugin.instancedata/src/org/opentosca/planbuilder/postphase/plugin/instancedata/bpel/Fragments.java
+++ b/org.opentosca.planbuilder.postphase.plugin.instancedata/src/org/opentosca/planbuilder/postphase/plugin/instancedata/bpel/Fragments.java
@@ -243,7 +243,8 @@ public class Fragments {
                                                              final String requestVariableName,
                                                              final String responseVariableName,
                                                              final String sourceInstanceIdVarName,
-                                                             final String targetInstanceIdVarName) throws IOException {
+                                                             final String targetInstanceIdVarName,
+                                                             final String serviceInstanceIdVarName) throws IOException {
         // <!-- $serviceInstanceURLVar, $nodeTemplateId, $ResponseVarName -->
         final URL url = FrameworkUtil.getBundle(this.getClass()).getBundleContext().getBundle()
                                      .getResource("BPEL4RESTLightPOST_RelationInstance_InstanceDataAPI.xml");
@@ -256,6 +257,7 @@ public class Fragments {
         bpel4RestString = bpel4RestString.replaceAll("\\$ResponseVarName", responseVariableName);
         bpel4RestString = bpel4RestString.replaceAll("\\$sourceInstanceIdVarName", sourceInstanceIdVarName);
         bpel4RestString = bpel4RestString.replaceAll("\\$targetInstanceIdVarName", targetInstanceIdVarName);
+        bpel4RestString = bpel4RestString.replaceAll("\\$serviceInstanceIdVarName", serviceInstanceIdVarName);
 
         return bpel4RestString;
     }

--- a/org.opentosca.planbuilder.postphase.plugin.instancedata/src/org/opentosca/planbuilder/postphase/plugin/instancedata/bpel/Handler.java
+++ b/org.opentosca.planbuilder.postphase.plugin.instancedata/src/org/opentosca/planbuilder/postphase/plugin/instancedata/bpel/Handler.java
@@ -1145,6 +1145,7 @@ public class Handler {
         final String sourceServiceTemplateUrlVarName = sourceContext.getServiceTemplateURLVar();
         final String targetServiceInstanceVarName = targetContext.getServiceInstanceURLVarName();
         final String targetServiceTemplateUrlVarName = targetContext.getServiceTemplateURLVar();
+        final String targetServiceInstanceIdVarName = targetContext.getServiceInstanceIDVarName();
 
         // create variable for all responses
         final String restCallResponseVarName = createRESTResponseVar(sourceContext);
@@ -1204,7 +1205,7 @@ public class Handler {
                                                                           createRelTInstanceReqVarName,
                                                                           restCallResponseVarName,
                                                                           targetServiceRelationSourceNodeInstanceIdVar,
-                                                                          targetServiceRelationTargetNodeInstanceIdVar);
+                                                                          targetServiceRelationTargetNodeInstanceIdVar, targetServiceInstanceIdVarName);
             Node createRelationInstanceExActiv = ModelUtils.string2dom(bpelString);
             createRelationInstanceExActiv = targetContext.importNode(createRelationInstanceExActiv);
             injectionPreElement.appendChild(createRelationInstanceExActiv);
@@ -1339,6 +1340,11 @@ public class Handler {
             return false;
         }
 
+        final String serviceInstanceIdVarName = context.getServiceInstanceIDVarName();
+        if(serviceInstanceIdVarName == null) {
+            return false;
+        }
+        
         /*
          * Pre Phase code
          */
@@ -1427,7 +1433,7 @@ public class Handler {
                                                                           context.getRelationshipTemplate().getId(),
                                                                           createRelTInstanceReqVarName,
                                                                           restCallResponseVarName,
-                                                                          sourceInstanceVarName, targetInstanceVarName);
+                                                                          sourceInstanceVarName, targetInstanceVarName,serviceInstanceIdVarName);
             Node createRelationInstanceExActiv = ModelUtils.string2dom(bpelString);
             createRelationInstanceExActiv = context.importNode(createRelationInstanceExActiv);
             injectionPreElement.appendChild(createRelationInstanceExActiv);


### PR DESCRIPTION
Fixes issue with Termination Plan not termination nodes properly when there are multiple nodes

+ added properly instantiating relation instances with the service instance id (fixes #107)
+ fixes termination by looping (again) over the available node instances of service instance

Signed-off-by: Kálmán Képes <kalman.kepes@iaas.uni-stuttgart.de>