### PR TITLE
Feature/plancompensation

### DIFF
--- a/org.opentosca.container.api/src/org/opentosca/container/api/controller/ServiceTemplateInstanceController.java
+++ b/org.opentosca.container.api/src/org/opentosca/container/api/controller/ServiceTemplateInstanceController.java
@@ -242,11 +242,15 @@ public class ServiceTemplateInstanceController {
     @ApiOperation(hidden = true, value = "")
     public Response updateServiceTemplateInstanceState(@PathParam("id") final Long id, final String request) {
         try {
-            this.instanceService.setServiceTemplateInstanceState(id, request);
+            this.instanceService.setServiceTemplateInstanceState(id, request);            
         }
         catch (final IllegalArgumentException e) { // this handles a null request too
             return Response.status(Status.BAD_REQUEST).build();
         }
+        if(request.contains("CREATED")) {
+            return Response.serverError().build();
+        }
+        
         return Response.ok().build();
     }
 

--- a/org.opentosca.container.api/src/org/opentosca/container/api/controller/ServiceTemplateInstanceController.java
+++ b/org.opentosca.container.api/src/org/opentosca/container/api/controller/ServiceTemplateInstanceController.java
@@ -247,9 +247,6 @@ public class ServiceTemplateInstanceController {
         catch (final IllegalArgumentException e) { // this handles a null request too
             return Response.status(Status.BAD_REQUEST).build();
         }
-        if(request.contains("CREATED")) {
-            return Response.serverError().build();
-        }
         
         return Response.ok().build();
     }

--- a/org.opentosca.container.core/src/org/opentosca/container/core/engine/impl/ToscaEngineServiceImpl.java
+++ b/org.opentosca.container.core/src/org/opentosca/container/core/engine/impl/ToscaEngineServiceImpl.java
@@ -210,7 +210,7 @@ public class ToscaEngineServiceImpl implements IToscaEngineService {
 
         // get the searched operation if available
         final Optional<TOperation> operation =
-            getOperationForType(csarID, typeID, interfaceName, operationName, inputParamListDefined);
+            getOperationForType(csarID, typeID, interfaceName, operationName, inputParamListDefined);        
 
         // check if parameters are defined
         return operation.map((op) -> !op.getInputParameters().getInputParameter().isEmpty()).orElse(false);

--- a/org.opentosca.container.product/config.ini
+++ b/org.opentosca.container.product/config.ini
@@ -1,6 +1,6 @@
 # Container Configuration
 # Your external IP address, e.g. 129.69.214.56
-org.opentosca.container.hostname=129.69.214.56
+org.opentosca.container.hostname=localhost
 org.opentosca.container.port=1337
 
 # IA Engine Configuration (endpoint and credentials)

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/artifactbasednodehandler/OperationChain.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/artifactbasednodehandler/OperationChain.java
@@ -19,6 +19,7 @@ import org.opentosca.planbuilder.plugins.artifactbased.IPlanBuilderProvPhaseOper
 import org.opentosca.planbuilder.plugins.artifactbased.IPlanBuilderProvPhaseParamOperationPlugin;
 import org.opentosca.planbuilder.plugins.context.PlanContext;
 import org.opentosca.planbuilder.plugins.context.Variable;
+import org.w3c.dom.Element;
 
 /**
  * <p>
@@ -376,8 +377,7 @@ public class OperationChain {
 
     public boolean executeOperationProvisioning(final BPELPlanContext context, final List<String> operationNames,
                                                 final Map<AbstractParameter, Variable> param2propertyMapping,
-                                                final Map<AbstractParameter, Variable> param2propertyOutputMapping,
-                                                final BPELScopePhaseType phase) {
+                                                final Map<AbstractParameter, Variable> param2propertyOutputMapping, Element elementToAppendTo) {
         int checkCount = 0;
         if (!this.provCandidates.isEmpty()) {
             final OperationNodeTypeImplCandidate provCandidate = this.provCandidates.get(this.selectedCandidateSet);
@@ -429,7 +429,7 @@ public class OperationChain {
                     final IPlanBuilderProvPhaseParamOperationPlugin paramPlugin =
                         (IPlanBuilderProvPhaseParamOperationPlugin) plugin;
                     if (!(op instanceof InterfaceDummy)) {
-                        if (paramPlugin.handle(context, op, ia, param2propertyMapping, phase)) {
+                        if (paramPlugin.handle(context, op, ia, param2propertyMapping, elementToAppendTo)) {
                             checkCount++;
                         }
                     } else {
@@ -454,7 +454,7 @@ public class OperationChain {
                             }
                         };
                         if (paramPlugin.handle(context, dummyOp, ia, param2propertyMapping, param2propertyOutputMapping,
-                                               phase)) {
+                                               elementToAppendTo)) {
                             checkCount++;
                         }
                     }
@@ -467,8 +467,7 @@ public class OperationChain {
     }
 
     public boolean executeOperationProvisioning(final BPELPlanContext context, final List<String> operationNames,
-                                                final Map<AbstractParameter, Variable> param2propertyMapping,
-                                                final BPELScopePhaseType phase) {
+                                                final Map<AbstractParameter, Variable> param2propertyMapping, Element elementToAppendTo) {
         int checkCount = 0;
         if (!this.provCandidates.isEmpty()) {
             final OperationNodeTypeImplCandidate provCandidate = this.provCandidates.get(this.selectedCandidateSet);
@@ -501,7 +500,7 @@ public class OperationChain {
                     final IPlanBuilderProvPhaseParamOperationPlugin paramPlugin =
                         (IPlanBuilderProvPhaseParamOperationPlugin) plugin;
                     if (!(op instanceof InterfaceDummy)) {
-                        if (paramPlugin.handle(context, op, ia, param2propertyMapping, phase)) {
+                        if (paramPlugin.handle(context, op, ia, param2propertyMapping, elementToAppendTo)) {
                             checkCount++;
                         }
                     } else {
@@ -525,7 +524,7 @@ public class OperationChain {
                                 return this.iface.getOperation(this.operationName).getInputParameters();
                             }
                         };
-                        if (paramPlugin.handle(context, dummyOp, ia, param2propertyMapping, phase)) {
+                        if (paramPlugin.handle(context, dummyOp, ia, param2propertyMapping, elementToAppendTo)) {
                             checkCount++;
                         }
                     }

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/context/BPELPlanContext.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/context/BPELPlanContext.java
@@ -78,9 +78,9 @@ public class BPELPlanContext extends PlanContext {
     private final BPELScopeHandler bpelTemplateHandler;
 
     private NodeRelationInstanceVariablesHandler nodeRelationInstanceHandler;
-    
-    
-    
+
+
+
     /**
      * Constructor
      *
@@ -93,9 +93,10 @@ public class BPELPlanContext extends PlanContext {
     public BPELPlanContext(final BPELPlan plan, final BPELScope templateBuildPlan, final Property2VariableMapping map,
                            final AbstractServiceTemplate serviceTemplate, String serviceInstanceURLVarName,
                            String serviceInstanceIDVarName, String serviceTemplateURLVarName, String csarFileName) {
-        super(plan, serviceTemplate, map, serviceInstanceURLVarName, serviceInstanceIDVarName, serviceTemplateURLVarName, csarFileName);
+        super(plan, serviceTemplate, map, serviceInstanceURLVarName, serviceInstanceIDVarName,
+              serviceTemplateURLVarName, csarFileName);
         this.templateBuildPlan = templateBuildPlan;
-        this.bpelTemplateHandler = new BPELScopeHandler();       
+        this.bpelTemplateHandler = new BPELScopeHandler();
         try {
             this.buildPlanHandler = new BPELPlanHandler();
             this.bpelProcessHandler = new BPELPlanHandler();
@@ -104,54 +105,54 @@ public class BPELPlanContext extends PlanContext {
         catch (final ParserConfigurationException e) {
             BPELPlanContext.LOG.warn("Coulnd't initialize internal handlers", e);
         }
- 
+
     }
-    
-    
+
+
     // TODO Refactor methods up to the BPEL specific methods
-    
+
     /**
-    *
-    * Looks for a Property with the same localName as the given String. The search is on either the
-    * Infrastructure on the Source or Target of the Template this TemplateContext belongs to.
-    *
-    * @param propertyName a String
-    * @param directionSink whether to look in direction of the sinks or sources (If Template is
-    *        NodeTemplate) or to search on the Source-/Target-Interface (if template is
-    *        RelationshipTemplate)
-    * @return a Variable Object with TemplateId and Name, if null the whole Infrastructure has no
-    *         Property with the specified localName
-    */
-   public PropertyVariable getPropertyVariable(final String propertyName, final boolean directionSink) {
-       final List<AbstractNodeTemplate> infraNodes = new ArrayList<>();
+     *
+     * Looks for a Property with the same localName as the given String. The search is on either the
+     * Infrastructure on the Source or Target of the Template this TemplateContext belongs to.
+     *
+     * @param propertyName a String
+     * @param directionSink whether to look in direction of the sinks or sources (If Template is
+     *        NodeTemplate) or to search on the Source-/Target-Interface (if template is
+     *        RelationshipTemplate)
+     * @return a Variable Object with TemplateId and Name, if null the whole Infrastructure has no
+     *         Property with the specified localName
+     */
+    public PropertyVariable getPropertyVariable(final String propertyName, final boolean directionSink) {
+        final List<AbstractNodeTemplate> infraNodes = new ArrayList<>();
 
-       if (isNodeTemplate()) {
-           if (directionSink) {
-               // get all NodeTemplates that are reachable from this
-               // nodeTemplate
-               ModelUtils.getNodesFromNodeToSink(getNodeTemplate(), infraNodes);
-           } else {
-               ModelUtils.getNodesFromNodeToSource(getNodeTemplate(), infraNodes);
-           }
-       } else {
-           if (directionSink) {
-               ModelUtils.getNodesFromNodeToSink(getRelationshipTemplate().getSource(), infraNodes);
-           } else {
-               ModelUtils.getNodesFromRelationToSink(getRelationshipTemplate(), infraNodes);
-           }
-       }
+        if (isNodeTemplate()) {
+            if (directionSink) {
+                // get all NodeTemplates that are reachable from this
+                // nodeTemplate
+                ModelUtils.getNodesFromNodeToSink(getNodeTemplate(), infraNodes);
+            } else {
+                ModelUtils.getNodesFromNodeToSource(getNodeTemplate(), infraNodes);
+            }
+        } else {
+            if (directionSink) {
+                ModelUtils.getNodesFromNodeToSink(getRelationshipTemplate().getSource(), infraNodes);
+            } else {
+                ModelUtils.getNodesFromRelationToSink(getRelationshipTemplate(), infraNodes);
+            }
+        }
 
-       for (final AbstractNodeTemplate infraNode : infraNodes) {
+        for (final AbstractNodeTemplate infraNode : infraNodes) {
 
-           for (PropertyVariable var : this.propertyMap.getNodePropertyVariables(this.serviceTemplate, infraNode)) {
-               if (var.getPropertyName().equals(propertyName)) {
-                   return var;
-               }
-           }
-       }
-       return null;
-   }
-   
+            for (PropertyVariable var : this.propertyMap.getNodePropertyVariables(this.serviceTemplate, infraNode)) {
+                if (var.getPropertyName().equals(propertyName)) {
+                    return var;
+                }
+            }
+        }
+        return null;
+    }
+
     /**
      * Returns the variable name of the first occurence of a property with the given Property name of
      * InfrastructureNodes
@@ -168,7 +169,7 @@ public class BPELPlanContext extends PlanContext {
         }
         return null;
     }
-   
+
     public String getTemplateId() {
         if (getNodeTemplate() != null) {
             return getNodeTemplate().getId();
@@ -177,7 +178,7 @@ public class BPELPlanContext extends PlanContext {
         }
 
     }
-    
+
     /**
      * Returns whether this context is for a nodeTemplate
      *
@@ -229,7 +230,7 @@ public class BPELPlanContext extends PlanContext {
     public boolean addStringValueToPlanResponse(final String localName) {
         return this.buildPlanHandler.addStringElementToPlanResponse(localName, this.templateBuildPlan.getBuildPlan());
     }
-    
+
     /**
      * Adds a variable to the TemplateBuildPlan of the template this context belongs to
      *
@@ -261,24 +262,25 @@ public class BPELPlanContext extends PlanContext {
         return true;
     }
 
-    public BPELPlanContext createContext(final AbstractNodeTemplate nodeTemplate, ActivityType... activityType) {                       
+    public BPELPlanContext createContext(final AbstractNodeTemplate nodeTemplate, ActivityType... activityType) {
         LOG.debug("Trying to create {} plan context for nodeTemplate {}", activityType, nodeTemplate);
-        for(BPELScope scope : this.templateBuildPlan.getBuildPlan().getTemplateBuildPlans()) {
-            if(scope.getNodeTemplate() != null && scope.getNodeTemplate().equals(nodeTemplate) && Arrays.asList(activityType).contains(scope.getActivity().getType())) {
+        for (BPELScope scope : this.templateBuildPlan.getBuildPlan().getTemplateBuildPlans()) {
+            if (scope.getNodeTemplate() != null && scope.getNodeTemplate().equals(nodeTemplate)
+                && Arrays.asList(activityType).contains(scope.getActivity().getType())) {
                 LOG.debug("Found scope of nodeTemplate");
-                return new BPELPlanContext((BPELPlan) this.plan, scope, this.propertyMap, this.serviceTemplate, this.serviceInstanceURLVarName,
-                                    this.serviceInstanceIDVarName, this.serviceTemplateURLVarName, this.csarFileName);
+                return new BPELPlanContext((BPELPlan) this.plan, scope, this.propertyMap, this.serviceTemplate,
+                    this.serviceInstanceURLVarName, this.serviceInstanceIDVarName, this.serviceTemplateURLVarName,
+                    this.csarFileName);
             }
         }
-        
-        
-        
+
+
+
         return null;
     }
-    
-    
-    
-    
+
+
+
     /**
      * Generates a bpel string variable with the given name + "_" + randomPositiveInt.
      *
@@ -329,8 +331,8 @@ public class BPELPlanContext extends PlanContext {
 
         // create context from this context and set the given nodeTemplate as
         // the node for the scope
-        final BPELPlanContext context = new BPELPlanContext((BPELPlan) this.plan,this.templateBuildPlan, this.propertyMap,
-            this.serviceTemplate, this.serviceInstanceURLVarName, this.serviceInstanceIDVarName,
+        final BPELPlanContext context = new BPELPlanContext((BPELPlan) this.plan, this.templateBuildPlan,
+            this.propertyMap, this.serviceTemplate, this.serviceInstanceURLVarName, this.serviceInstanceIDVarName,
             this.serviceTemplateURLVarName, this.csarFileName);
 
         context.templateBuildPlan.setNodeTemplate(nodeTemplate);
@@ -365,7 +367,7 @@ public class BPELPlanContext extends PlanContext {
         }
 
     }
-    
+
     /**
      * Returns alls InfrastructureEdges of the Template this context belongs to
      *
@@ -472,8 +474,8 @@ public class BPELPlanContext extends PlanContext {
         final AbstractRelationshipTemplate relationBackup = this.templateBuildPlan.getRelationshipTemplate();
         final AbstractNodeTemplate nodeBackup = this.templateBuildPlan.getNodeTemplate();
 
-        final BPELPlanContext context = new BPELPlanContext((BPELPlan) this.plan,this.templateBuildPlan, this.propertyMap,
-            this.serviceTemplate, this.serviceInstanceURLVarName, this.serviceInstanceIDVarName,
+        final BPELPlanContext context = new BPELPlanContext((BPELPlan) this.plan, this.templateBuildPlan,
+            this.propertyMap, this.serviceTemplate, this.serviceInstanceURLVarName, this.serviceInstanceIDVarName,
             this.serviceTemplateURLVarName, this.csarFileName);
 
         context.templateBuildPlan.setNodeTemplate(null);
@@ -491,7 +493,7 @@ public class BPELPlanContext extends PlanContext {
                                     final String operationName,
                                     final Map<AbstractParameter, Variable> param2propertyMapping,
                                     final Map<AbstractParameter, Variable> param2propertyOutputMapping,
-                                    final BPELScopePhaseType phase) {
+                                    final BPELScopePhaseType phase, Element elementToAppendTo) {
         final OperationChain chain = BPELScopeBuilder.createOperationCall(nodeTemplate, interfaceName, operationName);
         if (chain == null) {
             return false;
@@ -510,8 +512,8 @@ public class BPELPlanContext extends PlanContext {
 
         // create context from this context and set the given nodeTemplate as
         // the node for the scope
-        final BPELPlanContext context = new BPELPlanContext((BPELPlan) this.plan, this.templateBuildPlan, this.propertyMap,
-            this.serviceTemplate, this.serviceInstanceURLVarName, this.serviceInstanceIDVarName,
+        final BPELPlanContext context = new BPELPlanContext((BPELPlan) this.plan, this.templateBuildPlan,
+            this.propertyMap, this.serviceTemplate, this.serviceInstanceURLVarName, this.serviceInstanceIDVarName,
             this.serviceTemplateURLVarName, this.csarFileName);
 
         context.templateBuildPlan.setNodeTemplate(nodeTemplate);
@@ -524,10 +526,10 @@ public class BPELPlanContext extends PlanContext {
             chain.executeOperationProvisioning(context, opNames);
         } else {
             if (param2propertyOutputMapping == null) {
-                chain.executeOperationProvisioning(context, opNames, param2propertyMapping, phase);
+                chain.executeOperationProvisioning(context, opNames, param2propertyMapping, elementToAppendTo);
             } else {
                 chain.executeOperationProvisioning(context, opNames, param2propertyMapping, param2propertyOutputMapping,
-                                                   phase);
+                                                   elementToAppendTo);
             }
         }
 
@@ -562,8 +564,8 @@ public class BPELPlanContext extends PlanContext {
 
         // create context from this context and set the given nodeTemplate as
         // the node for the scope
-        final BPELPlanContext context = new BPELPlanContext((BPELPlan) this.plan, this.templateBuildPlan, this.propertyMap,
-            this.serviceTemplate, this.serviceInstanceURLVarName, this.serviceInstanceIDVarName,
+        final BPELPlanContext context = new BPELPlanContext((BPELPlan) this.plan, this.templateBuildPlan,
+            this.propertyMap, this.serviceTemplate, this.serviceInstanceURLVarName, this.serviceInstanceIDVarName,
             this.serviceTemplateURLVarName, this.csarFileName);
 
         context.templateBuildPlan.setNodeTemplate(nodeTemplate);
@@ -589,16 +591,18 @@ public class BPELPlanContext extends PlanContext {
 
         return true;
     }
-    
+
     /**
      * Returns a set of nodes that will be provisioned in the plan of this context
+     * 
      * @return
      */
     public Collection<AbstractNodeTemplate> getNodesInCreation() {
         Collection<AbstractActivity> activities = this.templateBuildPlan.getBuildPlan().getActivites();
         Collection<AbstractNodeTemplate> result = new HashSet<AbstractNodeTemplate>();
-        for(AbstractActivity activity : activities) {
-            if((activity instanceof NodeTemplateActivity) && (activity.getType().equals(ActivityType.PROVISIONING) || activity.getType().equals(ActivityType.MIGRATION))) {
+        for (AbstractActivity activity : activities) {
+            if ((activity instanceof NodeTemplateActivity) && (activity.getType().equals(ActivityType.PROVISIONING)
+                || activity.getType().equals(ActivityType.MIGRATION))) {
                 result.add(((NodeTemplateActivity) activity).getNodeTemplate());
             }
         }
@@ -613,7 +617,7 @@ public class BPELPlanContext extends PlanContext {
     public AbstractNodeTemplate getNodeTemplate() {
         return this.templateBuildPlan.getNodeTemplate();
     }
-    
+
     /**
      * Returns the name of variable which is the input message of the buildPlan
      *
@@ -632,7 +636,7 @@ public class BPELPlanContext extends PlanContext {
         return "output";
     }
 
-    
+
 
     /**
      * Returns the ProvPhase Element of the TemplateBuildPlan this context belongs to
@@ -644,6 +648,15 @@ public class BPELPlanContext extends PlanContext {
     }
 
     /**
+     * Returns the Provisioning Phase Sequence Element of the Compensation scope of this context
+     * 
+     * @return a Element which is a bpel sequence
+     */
+    public Element getProvisioningCompensationPhaseElement() {
+        return this.templateBuildPlan.getBpelCompensationHandlerScope().getBpelSequenceProvisioningPhaseElement();
+    }
+
+    /**
      * Returns the RelationshipTemplate this context handles
      *
      * @return an AbstractRelationshipTemplate if this context handle a RelationshipTemplate, else null
@@ -651,7 +664,7 @@ public class BPELPlanContext extends PlanContext {
     public AbstractRelationshipTemplate getRelationshipTemplate() {
         return this.templateBuildPlan.getRelationshipTemplate();
     }
-    
+
     // All BPEL related methods
     /**
      * Adds a copy element to the main assign element of the buildPlan this context belongs to
@@ -710,9 +723,10 @@ public class BPELPlanContext extends PlanContext {
                                                  final String myRole, final String partnerRole,
                                                  final boolean initializePartnerRole) {
         boolean check = true;
-                
+
         // here we set the qname with namespace of the plan "ba.example"
-        final QName partnerType = new QName(this.templateBuildPlan.getBuildPlan().getProcessNamespace(), partnerLinkType, "tns");
+        final QName partnerType =
+            new QName(this.templateBuildPlan.getBuildPlan().getProcessNamespace(), partnerLinkType, "tns");
         check &= addPLtoDeploy(partnerLinkName, partnerLinkType);
         check &= this.bpelTemplateHandler.addPartnerLink(partnerLinkName, partnerType, myRole, partnerRole,
                                                          initializePartnerRole, this.templateBuildPlan);
@@ -879,7 +893,7 @@ public class BPELPlanContext extends PlanContext {
         return this.templateBuildPlan.getBpelDocument().createElementNS(namespace, localName);
     }
 
-   
+
 
     /**
      * Returns the WSDL Ports of the given WSDL Service
@@ -964,7 +978,7 @@ public class BPELPlanContext extends PlanContext {
         return this.templateBuildPlan.getBpelSequencePrePhaseElement();
     }
 
-    
+
 
     /**
      * Returns the Services inside the given WSDL file which implement the given portType
@@ -1058,7 +1072,7 @@ public class BPELPlanContext extends PlanContext {
         return importNamespace(qname);
     }
 
-   
+
 
     /**
      * Registers the given namespace as extension inside the BuildPlan

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/fragments/BPELProcessFragments.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/fragments/BPELProcessFragments.java
@@ -53,14 +53,14 @@ public class BPELProcessFragments {
         this.docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
     }
 
-    private String loadFragmentResourceAsString(final String fileName) throws IOException {
+    public String loadFragmentResourceAsString(final String fileName) throws IOException {
         final URL url = FrameworkUtil.getBundle(this.getClass()).getResource(fileName);
         final File bpelfragmentfile = new File(FileLocator.toFileURL(url).getPath());
         String template = FileUtils.readFileToString(bpelfragmentfile);
         return template;
     }
 
-    private Node transformStringToNode(String xmlString) throws SAXException, IOException {
+    public Node transformStringToNode(String xmlString) throws SAXException, IOException {
         final InputSource is = new InputSource();
         is.setCharacterStream(new StringReader(xmlString));
         final Document doc = this.docBuilder.parse(is);

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/handlers/BPELFinalizer.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/handlers/BPELFinalizer.java
@@ -3,6 +3,7 @@ package org.opentosca.planbuilder.core.bpel.handlers;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -13,6 +14,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.opentosca.planbuilder.model.plan.AbstractPlan.Link;
 import org.opentosca.planbuilder.model.plan.bpel.BPELPlan;
 import org.opentosca.planbuilder.model.plan.bpel.BPELScope;
 import org.slf4j.Logger;
@@ -145,44 +147,47 @@ public class BPELFinalizer {
             parent.removeChild(extensions);
             buildPlan.setBpelExtensionsElement(null);
         }
-        
-        if(buildPlan.getBpelFaultHandlersElement().getChildNodes().getLength() == 0) {
-            buildPlan.getBpelDocument().removeChild(buildPlan.getBpelFaultHandlersElement());
-        } else {
-            this.buildPlanHandler.getMainCatchAllFaultHandlerSequenceElement(buildPlan).appendChild(buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "compensate"));
-            this.buildPlanHandler.getMainCatchAllFaultHandlerSequenceElement(buildPlan).appendChild(buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "rethrow"));
-        }
-        
-        
+
         makeSequential(buildPlan);
 
-        for (final BPELScope templateBuildPlan : buildPlan.getTemplateBuildPlans()) {            
+        for (final BPELScope templateBuildPlan : buildPlan.getTemplateBuildPlans()) {
             this.finalizeBPELScope(buildPlan, templateBuildPlan);
             this.finalizeBPELScope(buildPlan, templateBuildPlan.getBpelCompensationHandlerScope());
         }
+
+        if (buildPlan.getBpelFaultHandlersElement().getChildNodes().getLength() == 0) {
+            buildPlan.getBpelDocument().removeChild(buildPlan.getBpelFaultHandlersElement());
+        } else {
+             this.buildPlanHandler.getMainCatchAllFaultHandlerSequenceElement(buildPlan).appendChild(buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace,
+             "compensate"));
+            this.buildPlanHandler.getMainCatchAllFaultHandlerSequenceElement(buildPlan)
+                                 .appendChild(buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace,
+                                                                                          "rethrow"));
+        }
+
+
+
     }
-    
+
+
     private void finalizeBPELScope(final BPELPlan buildPlan, final BPELScope templateBuildPlan) {
-     // check if any phase of this templatebuildplan has no child
+        // check if any phase of this templatebuildplan has no child
         // elements, if it's empty, add an empty activity
         final Element prePhaseElement = templateBuildPlan.getBpelSequencePrePhaseElement();
         if (prePhaseElement.getChildNodes().getLength() == 0) {
-            final Element emptyElement =
-                buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "empty");
+            final Element emptyElement = buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "empty");
             prePhaseElement.appendChild(emptyElement);
         }
 
         final Element provPhaseElement = templateBuildPlan.getBpelSequenceProvisioningPhaseElement();
         if (provPhaseElement.getChildNodes().getLength() == 0) {
-            final Element emptyElement =
-                buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "empty");
+            final Element emptyElement = buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "empty");
             provPhaseElement.appendChild(emptyElement);
         }
 
         final Element postPhaseElement = templateBuildPlan.getBpelSequencePostPhaseElement();
         if (postPhaseElement.getChildNodes().getLength() == 0) {
-            final Element emptyElement =
-                buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "empty");
+            final Element emptyElement = buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "empty");
             postPhaseElement.appendChild(emptyElement);
         }
 
@@ -214,9 +219,8 @@ public class BPELFinalizer {
                 }
             }
             final Element joinCondition =
-                buildPlan.getBpelDocument()
-                         .createElementNS("http://docs.oasis-open.org/wsbpel/2.0/process/executable",
-                                          "joinCondition");
+                buildPlan.getBpelDocument().createElementNS("http://docs.oasis-open.org/wsbpel/2.0/process/executable",
+                                                            "joinCondition");
             joinCondition.setTextContent(condition);
             targets.insertBefore(joinCondition, targets.getFirstChild());
         }

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/handlers/BPELFinalizer.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/handlers/BPELFinalizer.java
@@ -155,92 +155,97 @@ public class BPELFinalizer {
         
         makeSequential(buildPlan);
 
-        for (final BPELScope templateBuildPlan : buildPlan.getTemplateBuildPlans()) {
-            // check if any phase of this templatebuildplan has no child
-            // elements, if it's empty, add an empty activity
-            final Element prePhaseElement = templateBuildPlan.getBpelSequencePrePhaseElement();
-            if (prePhaseElement.getChildNodes().getLength() == 0) {
-                final Element emptyElement =
-                    buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "empty");
-                prePhaseElement.appendChild(emptyElement);
-            }
+        for (final BPELScope templateBuildPlan : buildPlan.getTemplateBuildPlans()) {            
+            this.finalizeBPELScope(buildPlan, templateBuildPlan);
+            this.finalizeBPELScope(buildPlan, templateBuildPlan.getBpelCompensationHandlerScope());
+        }
+    }
+    
+    private void finalizeBPELScope(final BPELPlan buildPlan, final BPELScope templateBuildPlan) {
+     // check if any phase of this templatebuildplan has no child
+        // elements, if it's empty, add an empty activity
+        final Element prePhaseElement = templateBuildPlan.getBpelSequencePrePhaseElement();
+        if (prePhaseElement.getChildNodes().getLength() == 0) {
+            final Element emptyElement =
+                buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "empty");
+            prePhaseElement.appendChild(emptyElement);
+        }
 
-            final Element provPhaseElement = templateBuildPlan.getBpelSequenceProvisioningPhaseElement();
-            if (provPhaseElement.getChildNodes().getLength() == 0) {
-                final Element emptyElement =
-                    buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "empty");
-                provPhaseElement.appendChild(emptyElement);
-            }
+        final Element provPhaseElement = templateBuildPlan.getBpelSequenceProvisioningPhaseElement();
+        if (provPhaseElement.getChildNodes().getLength() == 0) {
+            final Element emptyElement =
+                buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "empty");
+            provPhaseElement.appendChild(emptyElement);
+        }
 
-            final Element postPhaseElement = templateBuildPlan.getBpelSequencePostPhaseElement();
-            if (postPhaseElement.getChildNodes().getLength() == 0) {
-                final Element emptyElement =
-                    buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "empty");
-                postPhaseElement.appendChild(emptyElement);
-            }
+        final Element postPhaseElement = templateBuildPlan.getBpelSequencePostPhaseElement();
+        if (postPhaseElement.getChildNodes().getLength() == 0) {
+            final Element emptyElement =
+                buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "empty");
+            postPhaseElement.appendChild(emptyElement);
+        }
 
-            // check if sources, targets, variables or partnerlinks is empty, if
-            // yes remove each of them
-            final Element targets = templateBuildPlan.getBpelTargetsElement();
-            if (targets.getChildNodes().getLength() == 0) {
-                final Node parent = targets.getParentNode();
-                parent.removeChild(targets);
-                templateBuildPlan.setBpelTargetsElement(null);
-            } else {
-                // add join conditions, where all templates which are target of
-                // a
-                // edge should be used in a conjuction
-                final NodeList targetsChildren = targets.getChildNodes();
-                final List<String> targetLinkNames = new ArrayList<>();
-                for (int index = 0; index < targetsChildren.getLength(); index++) {
-                    final Node targetNode = targetsChildren.item(index);
-                    if (targetNode.getLocalName().equals("target")) {
-                        targetLinkNames.add(targetNode.getAttributes().getNamedItem("linkName").getTextContent());
-                    }
+        // check if sources, targets, variables or partnerlinks is empty, if
+        // yes remove each of them
+        final Element targets = templateBuildPlan.getBpelTargetsElement();
+        if (targets.getChildNodes().getLength() == 0) {
+            final Node parent = targets.getParentNode();
+            parent.removeChild(targets);
+            templateBuildPlan.setBpelTargetsElement(null);
+        } else {
+            // add join conditions, where all templates which are target of
+            // a
+            // edge should be used in a conjuction
+            final NodeList targetsChildren = targets.getChildNodes();
+            final List<String> targetLinkNames = new ArrayList<>();
+            for (int index = 0; index < targetsChildren.getLength(); index++) {
+                final Node targetNode = targetsChildren.item(index);
+                if (targetNode.getLocalName().equals("target")) {
+                    targetLinkNames.add(targetNode.getAttributes().getNamedItem("linkName").getTextContent());
                 }
-                String condition = "";
-                for (int index = 0; index < targetLinkNames.size(); index++) {
-                    if (index == 0) {
-                        condition += "$" + targetLinkNames.get(index);
-                    } else {
-                        condition += " and $" + targetLinkNames.get(index);
-                    }
+            }
+            String condition = "";
+            for (int index = 0; index < targetLinkNames.size(); index++) {
+                if (index == 0) {
+                    condition += "$" + targetLinkNames.get(index);
+                } else {
+                    condition += " and $" + targetLinkNames.get(index);
                 }
-                final Element joinCondition =
-                    buildPlan.getBpelDocument()
-                             .createElementNS("http://docs.oasis-open.org/wsbpel/2.0/process/executable",
-                                              "joinCondition");
-                joinCondition.setTextContent(condition);
-                targets.insertBefore(joinCondition, targets.getFirstChild());
             }
+            final Element joinCondition =
+                buildPlan.getBpelDocument()
+                         .createElementNS("http://docs.oasis-open.org/wsbpel/2.0/process/executable",
+                                          "joinCondition");
+            joinCondition.setTextContent(condition);
+            targets.insertBefore(joinCondition, targets.getFirstChild());
+        }
 
-            final Element sources = templateBuildPlan.getBpelSourcesElement();
-            if (sources.getChildNodes().getLength() == 0) {
-                final Node parent = sources.getParentNode();
-                parent.removeChild(sources);
-                templateBuildPlan.setBpelSourcesElement(null);
-            }
+        final Element sources = templateBuildPlan.getBpelSourcesElement();
+        if (sources.getChildNodes().getLength() == 0) {
+            final Node parent = sources.getParentNode();
+            parent.removeChild(sources);
+            templateBuildPlan.setBpelSourcesElement(null);
+        }
 
-            final Element correlationSets = templateBuildPlan.getBpelCorrelationSets();
-            if (correlationSets.getChildNodes().getLength() == 0) {
-                final Node parent = correlationSets.getParentNode();
-                parent.removeChild(correlationSets);
-                templateBuildPlan.setBpelCorrelationSets(null);
-            }
+        final Element correlationSets = templateBuildPlan.getBpelCorrelationSets();
+        if (correlationSets.getChildNodes().getLength() == 0) {
+            final Node parent = correlationSets.getParentNode();
+            parent.removeChild(correlationSets);
+            templateBuildPlan.setBpelCorrelationSets(null);
+        }
 
-            final Element variables = templateBuildPlan.getBpelVariablesElement();
-            if (variables.getChildNodes().getLength() == 0) {
-                final Node parent = variables.getParentNode();
-                parent.removeChild(variables);
-                templateBuildPlan.setBpelVariablesElement(null);
-            }
+        final Element variables = templateBuildPlan.getBpelVariablesElement();
+        if (variables.getChildNodes().getLength() == 0) {
+            final Node parent = variables.getParentNode();
+            parent.removeChild(variables);
+            templateBuildPlan.setBpelVariablesElement(null);
+        }
 
-            final Element partnerlinks = templateBuildPlan.getBpelPartnerLinksElement();
-            if (partnerlinks.getChildNodes().getLength() == 0) {
-                final Node parent = partnerlinks.getParentNode();
-                parent.removeChild(partnerlinks);
-                templateBuildPlan.setBpelPartnerLinks(null);
-            }
+        final Element partnerlinks = templateBuildPlan.getBpelPartnerLinksElement();
+        if (partnerlinks.getChildNodes().getLength() == 0) {
+            final Node parent = partnerlinks.getParentNode();
+            parent.removeChild(partnerlinks);
+            templateBuildPlan.setBpelPartnerLinks(null);
         }
     }
 

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/handlers/BPELFinalizer.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/handlers/BPELFinalizer.java
@@ -149,6 +149,7 @@ public class BPELFinalizer {
         if(buildPlan.getBpelFaultHandlersElement().getChildNodes().getLength() == 0) {
             buildPlan.getBpelDocument().removeChild(buildPlan.getBpelFaultHandlersElement());
         } else {
+            this.buildPlanHandler.getMainCatchAllFaultHandlerSequenceElement(buildPlan).appendChild(buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "compensate"));
             this.buildPlanHandler.getMainCatchAllFaultHandlerSequenceElement(buildPlan).appendChild(buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "rethrow"));
         }
         

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/handlers/BPELPlanHandler.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/handlers/BPELPlanHandler.java
@@ -998,24 +998,25 @@ public class BPELPlanHandler {
         final Map<AbstractActivity, BPELScope> abstract2bpelMap = new HashMap<>();
 
         for (final AbstractActivity activity : plan.getActivites()) {
+            BPELScope newEmpty3SequenceScopeBPELActivity = null;
             if (activity instanceof NodeTemplateActivity) {
                 final NodeTemplateActivity ntActivity = (NodeTemplateActivity) activity;
-                final BPELScope newEmpty3SequenceScopeBPELActivity =
-                    this.bpelScopeHandler.createTemplateBuildPlan(ntActivity, plan);
+                newEmpty3SequenceScopeBPELActivity = this.bpelScopeHandler.createTemplateBuildPlan(ntActivity, plan, "");
                 plan.addTemplateBuildPlan(newEmpty3SequenceScopeBPELActivity);
-                abstract2bpelMap.put(ntActivity, newEmpty3SequenceScopeBPELActivity);                             
-                
-                final BPELScope newCompensationHandlerScope = this.bpelScopeHandler.createTemplateBuildPlan(ntActivity, plan);                                
-                newEmpty3SequenceScopeBPELActivity.setBpelCompensationHandlerScope(newCompensationHandlerScope);                
+                abstract2bpelMap.put(ntActivity, newEmpty3SequenceScopeBPELActivity);
+
+                final BPELScope newCompensationHandlerScope =
+                    this.bpelScopeHandler.createTemplateBuildPlan(ntActivity, plan, "compensation");               
+                newEmpty3SequenceScopeBPELActivity.setBpelCompensationHandlerScope(newCompensationHandlerScope);
             } else if (activity instanceof RelationshipTemplateActivity) {
                 final RelationshipTemplateActivity rtActivity = (RelationshipTemplateActivity) activity;
-                final BPELScope newEmpty3SequenceScopeBPELActivity =
-                    this.bpelScopeHandler.createTemplateBuildPlan(rtActivity, plan);
+                newEmpty3SequenceScopeBPELActivity = this.bpelScopeHandler.createTemplateBuildPlan(rtActivity, plan, "");
                 plan.addTemplateBuildPlan(newEmpty3SequenceScopeBPELActivity);
                 abstract2bpelMap.put(rtActivity, newEmpty3SequenceScopeBPELActivity);
-                
-                final BPELScope newCompensationHandlerScope = this.bpelScopeHandler.createTemplateBuildPlan(rtActivity, plan);                  
-                newEmpty3SequenceScopeBPELActivity.setBpelCompensationHandlerScope(newCompensationHandlerScope);                                              
+
+                final BPELScope newCompensationHandlerScope =
+                    this.bpelScopeHandler.createTemplateBuildPlan(rtActivity, plan, "compensation");
+                newEmpty3SequenceScopeBPELActivity.setBpelCompensationHandlerScope(newCompensationHandlerScope);
             }
         }
 
@@ -1076,9 +1077,9 @@ public class BPELPlanHandler {
 
 
     public Element getMainCatchAllFaultHandlerSequenceElement(BPELPlan plan) {
-        return (Element) plan.getBpelFaultHandlersElement().getElementsByTagName("catchAll").item(0).getFirstChild();        
+        return (Element) plan.getBpelFaultHandlersElement().getElementsByTagName("catchAll").item(0).getFirstChild();
     }
-    
+
 
     public boolean assignInitValueToVariable(Variable var, String value, BPELPlan plan) {
         return assignInitValueToVariable(var.getVariableName(), value, plan);
@@ -1095,9 +1096,12 @@ public class BPELPlanHandler {
         // initialize processElement and append to document
         newBuildPlan.setBpelProcessElement(newBuildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace,
                                                                                           "process"));
+        newBuildPlan.getBpelProcessElement().setAttribute("suppressJoinFailure", "no");
+        
         newBuildPlan.getBpelDocument().appendChild(newBuildPlan.getBpelProcessElement());
+        
 
-        // FIXME declare xml schema namespace
+        // declare xml schema namespace
         newBuildPlan.getBpelProcessElement().setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:xsd",
                                                             "http://www.w3.org/2001/XMLSchema");
 
@@ -1114,19 +1118,16 @@ public class BPELPlanHandler {
 
         newBuildPlan.setBpelFaultHandlersElement(newBuildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace,
                                                                                                 "faultHandlers"));
-        
-        
+
+
         newBuildPlan.getBpelProcessElement().appendChild(newBuildPlan.getBpelFaultHandlersElement());
-                        
-        Element catchAll = newBuildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace,
-            "catchAll");
-        Element errorScope = newBuildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace,
-            "sequence");
-        
-        errorScope.appendChild(newBuildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace,
-            "empty"));
+
+        Element catchAll = newBuildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "catchAll");
+        Element errorScope = newBuildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "sequence");
+
+        errorScope.appendChild(newBuildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "empty"));
         catchAll.appendChild(errorScope);
-        
+
         newBuildPlan.getBpelFaultHandlersElement().appendChild(catchAll);
 
         // TODO this is here to not to forget that the imports elements aren't
@@ -1163,11 +1164,14 @@ public class BPELPlanHandler {
         newBuildPlan.setBpelMainSequencePropertyAssignElement(newBuildPlan.getBpelDocument()
                                                                           .createElementNS(BPELPlan.bpelNamespace,
                                                                                            "assign"));
-        newBuildPlan.getBpelMainSequenceElement().appendChild(newBuildPlan.getBpelMainSequencePropertyAssignElement());
-
+        newBuildPlan.getBpelMainSequenceElement().appendChild(newBuildPlan.getBpelMainSequencePropertyAssignElement());        
+        
         // init and append main sequence flow element to main sequence element
         newBuildPlan.setBpelMainFlowElement(newBuildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace,
                                                                                            "flow"));
+        
+        newBuildPlan.getBpelMainFlowElement().setAttribute("suppressJoinFailure", "no");
+        
         newBuildPlan.getBpelMainSequenceElement().appendChild(newBuildPlan.getBpelMainFlowElement());
 
         // init and append flow links element

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/handlers/BPELPlanHandler.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/handlers/BPELPlanHandler.java
@@ -1003,13 +1003,19 @@ public class BPELPlanHandler {
                 final BPELScope newEmpty3SequenceScopeBPELActivity =
                     this.bpelScopeHandler.createTemplateBuildPlan(ntActivity, plan);
                 plan.addTemplateBuildPlan(newEmpty3SequenceScopeBPELActivity);
-                abstract2bpelMap.put(ntActivity, newEmpty3SequenceScopeBPELActivity);
+                abstract2bpelMap.put(ntActivity, newEmpty3SequenceScopeBPELActivity);                             
+                
+                final BPELScope newCompensationHandlerScope = this.bpelScopeHandler.createTemplateBuildPlan(ntActivity, plan);                                
+                newEmpty3SequenceScopeBPELActivity.setBpelCompensationHandlerScope(newCompensationHandlerScope);                
             } else if (activity instanceof RelationshipTemplateActivity) {
                 final RelationshipTemplateActivity rtActivity = (RelationshipTemplateActivity) activity;
                 final BPELScope newEmpty3SequenceScopeBPELActivity =
                     this.bpelScopeHandler.createTemplateBuildPlan(rtActivity, plan);
                 plan.addTemplateBuildPlan(newEmpty3SequenceScopeBPELActivity);
                 abstract2bpelMap.put(rtActivity, newEmpty3SequenceScopeBPELActivity);
+                
+                final BPELScope newCompensationHandlerScope = this.bpelScopeHandler.createTemplateBuildPlan(rtActivity, plan);                  
+                newEmpty3SequenceScopeBPELActivity.setBpelCompensationHandlerScope(newCompensationHandlerScope);                                              
             }
         }
 

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/handlers/BPELScopeHandler.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/handlers/BPELScopeHandler.java
@@ -230,28 +230,33 @@ public class BPELScopeHandler {
     }
 
 
-    
-    public BPELScope createTemplateBuildPlan(final NodeTemplateActivity nodeTemplateActivity, final BPELPlan buildPlan) {        
+
+    public BPELScope createTemplateBuildPlan(final NodeTemplateActivity nodeTemplateActivity, final BPELPlan buildPlan,
+                                             String namePrefix) {
         final BPELScope newTemplateBuildPlan = new BPELScope(nodeTemplateActivity);
-        this.initializeXMLElements(newTemplateBuildPlan, buildPlan);       
-        this.setName(this.getNCNameFromString(nodeTemplateActivity.getNodeTemplate().getId()) + "_" + nodeTemplateActivity.getType(), newTemplateBuildPlan);
+        this.initializeXMLElements(newTemplateBuildPlan, buildPlan);
+        this.setName(this.getNCNameFromString(((namePrefix == null || namePrefix.isEmpty()) ? "" : namePrefix + "_")
+            + nodeTemplateActivity.getNodeTemplate().getId()) + "_" + nodeTemplateActivity.getType(),
+                     newTemplateBuildPlan);
         newTemplateBuildPlan.setNodeTemplate(nodeTemplateActivity.getNodeTemplate());
         return newTemplateBuildPlan;
     }
 
- 
-    
+
+
     public BPELScope createTemplateBuildPlan(final RelationshipTemplateActivity relationshipTemplateActivity,
-                                             final BPELPlan buildPlan) {
-    
+                                             final BPELPlan buildPlan, String namePrefix) {
+
         final BPELScope newTemplateBuildPlan = new BPELScope(relationshipTemplateActivity);
-        this.initializeXMLElements(newTemplateBuildPlan, buildPlan);        
-        this.setName(this.getNCNameFromString(relationshipTemplateActivity.getRelationshipTemplate().getId()) + "_" + relationshipTemplateActivity.getType(), newTemplateBuildPlan);
+        this.initializeXMLElements(newTemplateBuildPlan, buildPlan);
+        this.setName(this.getNCNameFromString(((namePrefix == null || namePrefix.isEmpty()) ? "" : namePrefix + "_")
+            + relationshipTemplateActivity.getRelationshipTemplate().getId()) + "_"
+            + relationshipTemplateActivity.getType(), newTemplateBuildPlan);
         newTemplateBuildPlan.setRelationshipTemplate(relationshipTemplateActivity.getRelationshipTemplate());
         return newTemplateBuildPlan;
     }
 
-   
+
 
     /**
      * Returns the names of the links declared in the sources element of the given TemplateBuildPlan
@@ -445,7 +450,7 @@ public class BPELScopeHandler {
     public void initializeXMLElements(final BPELScope newTemplateBuildPlan, final BPELPlan buildPlan) {
         // set the build plan of the new template buildplan
         newTemplateBuildPlan.setBuildPlan(buildPlan);
-        
+
         // initialize bpelScopeElement and append to flow
         newTemplateBuildPlan.setBpelScopeElement(newTemplateBuildPlan.getBpelDocument()
                                                                      .createElementNS(BPELPlan.bpelNamespace, "scope"));

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/handlers/BPELScopeHandler.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/handlers/BPELScopeHandler.java
@@ -445,8 +445,7 @@ public class BPELScopeHandler {
     public void initializeXMLElements(final BPELScope newTemplateBuildPlan, final BPELPlan buildPlan) {
         // set the build plan of the new template buildplan
         newTemplateBuildPlan.setBuildPlan(buildPlan);
-
-        newTemplateBuildPlan.getBuildPlan();
+        
         // initialize bpelScopeElement and append to flow
         newTemplateBuildPlan.setBpelScopeElement(newTemplateBuildPlan.getBpelDocument()
                                                                      .createElementNS(BPELPlan.bpelNamespace, "scope"));

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/tosca/handlers/NodeRelationInstanceVariablesHandler.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/tosca/handlers/NodeRelationInstanceVariablesHandler.java
@@ -742,6 +742,16 @@ public class NodeRelationInstanceVariablesHandler {
             templateMainScopeNode.removeChild(correlationSets);
 
         }
+        
+        if(((Element) templateMainScopeNode).getElementsByTagName("compensationHandler").getLength() != 0) {
+            final Element compensationHandler = (Element) ((Element) templateMainScopeNode).getElementsByTagName("compensationHandler").item(0);
+            
+            final Node cloneCompensationHandler = compensationHandler.cloneNode(true);
+            
+            forEachScopeElement.appendChild(cloneCompensationHandler);
+            templateMainScopeNode.removeChild(compensationHandler);
+        }
+        
         final Element sequenceElement = context.createElement(BPELPlan.bpelNamespace, "sequence");
 
         sequenceElement.appendChild(context.importNode(context.getPrePhaseElement().cloneNode(true)));

--- a/org.opentosca.planbuilder.integration/src/org/opentosca/planbuilder/importer/context/impl/TopologyTemplateImpl.java
+++ b/org.opentosca.planbuilder.integration/src/org/opentosca/planbuilder/importer/context/impl/TopologyTemplateImpl.java
@@ -50,7 +50,7 @@ public class TopologyTemplateImpl extends AbstractTopologyTemplate {
                                 final QName serviceTemplateId) {
         this.topologyTemplate = topologyTemplate;
         this.definitions = definitions;
-        this.serviceTemplateId = serviceTemplateId;
+        this.serviceTemplateId = serviceTemplateId;                
         setUpTemplates();
         setUpRelations();
     }

--- a/org.opentosca.planbuilder.model/src/org/opentosca/planbuilder/model/plan/bpel/BPELScope.java
+++ b/org.opentosca.planbuilder.model/src/org/opentosca/planbuilder/model/plan/bpel/BPELScope.java
@@ -46,7 +46,9 @@ public class BPELScope{
     private Element bpelMainSequenceElement;
     private Element bpelSequencePrePhaseElement;
     private Element bpelSequenceProvisioningPhaseElement;
-    private Element bpelSequencePostPhaseElement;
+    private Element bpelSequencePostPhaseElement;    
+    
+    private BPELScope bpelCompensationScope;
 
     private AbstractNodeTemplate nodeTemplate = null;
     private AbstractRelationshipTemplate relationshipTemplate = null;
@@ -252,6 +254,27 @@ public class BPELScope{
     public void setBpelSequencePostPhaseElement(final Element bpelSequencePostPhaseElement) {
         this.bpelSequencePostPhaseElement = bpelSequencePostPhaseElement;
     }
+
+    /**
+     * Returns the scope containing the compensation activities of this scope
+     * @return a DOM Element
+     */
+    public BPELScope getBpelCompensationHandlerScope() {
+        return bpelCompensationScope;
+    }
+
+    /**
+     * Sets the scope as the compensation handler of this scope 
+     * @param bpelCompensationScope a BPEL DOM Element with a compensation handler
+     */
+    public void setBpelCompensationHandlerScope(BPELScope bpelCompensationScope) {
+        this.bpelCompensationScope = bpelCompensationScope;        
+        Element compensationHandlerElement = this.buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "compensationHandler");                
+        compensationHandlerElement.appendChild(this.bpelCompensationScope.getBpelScopeElement());
+        this.bpelScopeElement.appendChild(compensationHandlerElement);        
+    }
+
+    
 
     /**
      * Gets the NodeTemplate this TemplateBuildPlan belongs to

--- a/org.opentosca.planbuilder.model/src/org/opentosca/planbuilder/model/plan/bpel/BPELScope.java
+++ b/org.opentosca.planbuilder.model/src/org/opentosca/planbuilder/model/plan/bpel/BPELScope.java
@@ -47,7 +47,8 @@ public class BPELScope{
     private Element bpelSequencePrePhaseElement;
     private Element bpelSequenceProvisioningPhaseElement;
     private Element bpelSequencePostPhaseElement;    
-    
+
+
     private BPELScope bpelCompensationScope;
 
     private AbstractNodeTemplate nodeTemplate = null;
@@ -254,6 +255,8 @@ public class BPELScope{
     public void setBpelSequencePostPhaseElement(final Element bpelSequencePostPhaseElement) {
         this.bpelSequencePostPhaseElement = bpelSequencePostPhaseElement;
     }
+    
+
 
     /**
      * Returns the scope containing the compensation activities of this scope
@@ -270,8 +273,8 @@ public class BPELScope{
     public void setBpelCompensationHandlerScope(BPELScope bpelCompensationScope) {
         this.bpelCompensationScope = bpelCompensationScope;        
         Element compensationHandlerElement = this.buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "compensationHandler");                
-        compensationHandlerElement.appendChild(this.bpelCompensationScope.getBpelScopeElement());
-        this.bpelScopeElement.appendChild(compensationHandlerElement);        
+        compensationHandlerElement.appendChild(this.bpelCompensationScope.getBpelScopeElement());        
+        this.bpelScopeElement.insertBefore(compensationHandlerElement, this.bpelMainSequenceElement);        
     }
 
     

--- a/org.opentosca.planbuilder.postphase.plugin.instancedata/src/org/opentosca/planbuilder/postphase/plugin/instancedata/bpel/Handler.java
+++ b/org.opentosca.planbuilder.postphase.plugin.instancedata/src/org/opentosca/planbuilder/postphase/plugin/instancedata/bpel/Handler.java
@@ -1887,7 +1887,7 @@ public class Handler {
         // generate call to method
         context.executeOperation(node, Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM,
                                  Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM_RUNSCRIPT, inputParams,
-                                 outputParams, BPELScopePhaseType.PRE);
+                                 outputParams, BPELScopePhaseType.PRE, context.getPrePhaseElement());
 
         // check result and eventually throw error
 

--- a/org.opentosca.planbuilder.postphase.plugin.monitoring/src/org/opentosca/planbuilder/postphase/plugin/monitoring/bpel/impl/BPELMonitoringPlugin.java
+++ b/org.opentosca.planbuilder.postphase.plugin.monitoring/src/org/opentosca/planbuilder/postphase/plugin/monitoring/bpel/impl/BPELMonitoringPlugin.java
@@ -65,7 +65,7 @@ public class BPELMonitoringPlugin implements IPlanBuilderPostPhasePlugin<BPELPla
 
 
         return context.executeOperation(nodeTemplate, this.monitoringInterfaceName, this.monitoringOperationName, null,
-                                        null, BPELScopePhaseType.POST);
+                                        null, BPELScopePhaseType.POST, context.getPostPhaseElement());
     }
 
     @Override
@@ -134,8 +134,7 @@ public class BPELMonitoringPlugin implements IPlanBuilderPostPhasePlugin<BPELPla
 
 
         this.invokerPlugin.handleArtifactReferenceUpload(deplArti.getArtifactRef().getArtifactReferences().get(0),
-                                                         context, sshIpVar, sshUserVar, sshKeyVar, infraNode,
-                                                         BPELScopePhaseType.PROVISIONING);
+                                                         context, sshIpVar, sshUserVar, sshKeyVar, infraNode, context.getProvisioningPhaseElement());
     }
 
     private AbstractDeploymentArtifact fetchConfigurationArtifact(final AbstractNodeTemplate nodeTemplate) {

--- a/org.opentosca.planbuilder.prephase.plugin.fileupload/src/org/opentosca/planbuilder/prephase/plugin/fileupload/bpel/handler/BPELPrePhasePluginHandler.java
+++ b/org.opentosca.planbuilder.prephase.plugin.fileupload/src/org/opentosca/planbuilder/prephase/plugin/fileupload/bpel/handler/BPELPrePhasePluginHandler.java
@@ -149,7 +149,7 @@ public class BPELPrePhasePluginHandler {
         for (final AbstractArtifactReference ref : refs) {
             // upload da ref and unzip it
             this.invokerPlugin.handleArtifactReferenceUpload(ref, templateContext, serverIpPropWrapper, sshUserVariable,
-                                                             sshKeyVariable, infraTemplate, BPELScopePhaseType.PRE);
+                                                             sshKeyVariable, infraTemplate, templateContext.getPrePhaseElement());
         }
 
         return true;

--- a/org.opentosca.planbuilder.provphase.plugin.ansibleoperation/src/org/opentosca/planbuilder/provphase/plugin/ansibleoperation/bpel/BPELAnsibleOperationPlugin.java
+++ b/org.opentosca.planbuilder.provphase.plugin.ansibleoperation/src/org/opentosca/planbuilder/provphase/plugin/ansibleoperation/bpel/BPELAnsibleOperationPlugin.java
@@ -10,6 +10,7 @@ import org.opentosca.planbuilder.model.tosca.AbstractParameter;
 import org.opentosca.planbuilder.plugins.context.Variable;
 import org.opentosca.planbuilder.provphase.plugin.ansibleoperation.bpel.handler.BPELAnsibleOperationPluginHandler;
 import org.opentosca.planbuilder.provphase.plugin.ansibleoperation.core.AnsibleOperationPlugin;
+import org.w3c.dom.Element;
 
 /**
  * <p>
@@ -45,8 +46,7 @@ public class BPELAnsibleOperationPlugin extends AnsibleOperationPlugin<BPELPlanC
     @Override
     public boolean handle(final BPELPlanContext context, final AbstractOperation operation,
                           final AbstractImplementationArtifact ia,
-                          final Map<AbstractParameter, Variable> param2propertyMapping,
-                          final BPELScopePhaseType phase) {
+                          final Map<AbstractParameter, Variable> param2propertyMapping, Element elementToAppendTo) {
         // TODO Auto-generated method stub
         return false;
     }
@@ -64,8 +64,7 @@ public class BPELAnsibleOperationPlugin extends AnsibleOperationPlugin<BPELPlanC
     public boolean handle(final BPELPlanContext context, final AbstractOperation operation,
                           final AbstractImplementationArtifact ia,
                           final Map<AbstractParameter, Variable> param2propertyMapping,
-                          final Map<AbstractParameter, Variable> param2PropertyOutputMapping,
-                          final BPELScopePhaseType phase) {
+                          final Map<AbstractParameter, Variable> param2PropertyOutputMapping, Element elementToAppendTo) {
         // TODO Auto-generated method stub
         return false;
     }

--- a/org.opentosca.planbuilder.provphase.plugin.ansibleoperation/src/org/opentosca/planbuilder/provphase/plugin/ansibleoperation/bpel/handler/BPELAnsibleOperationPluginHandler.java
+++ b/org.opentosca.planbuilder.provphase.plugin.ansibleoperation/src/org/opentosca/planbuilder/provphase/plugin/ansibleoperation/bpel/handler/BPELAnsibleOperationPluginHandler.java
@@ -161,7 +161,7 @@ public class BPELAnsibleOperationPluginHandler implements AnsibleOperationPlugin
                 runScriptRequestInputParams.put("sshUser", sshUserVariable);
                 runScriptRequestInputParams.put("script", runShScriptStringVar);
                 this.invokerPlugin.handle(templateContext, templateId, true, "runScript", "InterfaceUbuntu", runScriptRequestInputParams,
-                                          new HashMap<String, Variable>(), BPELScopePhaseType.PROVISIONING);
+                                          new HashMap<String, Variable>(), templateContext.getProvisioningPhaseElement());
 
                 break;
             case Properties.OPENTOSCA_DECLARATIVE_PROPERTYNAME_VMIP:
@@ -172,7 +172,7 @@ public class BPELAnsibleOperationPluginHandler implements AnsibleOperationPlugin
                 runScriptRequestInputParams.put("Script", runShScriptStringVar);
                 this.invokerPlugin.handle(templateContext, templateId, true, "runScript",
                                           Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM, runScriptRequestInputParams,
-                                          new HashMap<String, Variable>(), BPELScopePhaseType.PROVISIONING);
+                                          new HashMap<String, Variable>(),  templateContext.getProvisioningPhaseElement());
                 break;
             default:
                 return false;

--- a/org.opentosca.planbuilder.provphase.plugin.invoker/META-INF/resources/ifFaultMessageThrowFault.xml
+++ b/org.opentosca.planbuilder.provphase.plugin.invoker/META-INF/resources/ifFaultMessageThrowFault.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpel:if xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
+<!--  $xpath1Expr, $faultPrefix, $faultNamespace, $faultLocalName-->
+	<bpel:condition expressionLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0"> 
+		<![CDATA[$xpath1Expr]]>
+	</bpel:condition>
+	<bpel:throw xmlns:$faultPrefix="$faultNamespace" faultName="$faultPrefix:$faultLocalName" faulVariable="$faultVariable"/>
+</bpel:if>

--- a/org.opentosca.planbuilder.provphase.plugin.invoker/src/org/opentosca/planbuilder/provphase/plugin/invoker/bpel/BPELInvokerPlugin.java
+++ b/org.opentosca.planbuilder.provphase.plugin.invoker/src/org/opentosca/planbuilder/provphase/plugin/invoker/bpel/BPELInvokerPlugin.java
@@ -24,6 +24,7 @@ import org.opentosca.planbuilder.plugins.context.Variable;
 import org.opentosca.planbuilder.provphase.plugin.invoker.bpel.handlers.BPELInvokerPluginHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.w3c.dom.Element;
 
 /**
  * Copyright 2014 IAAS University of Stuttgart <br>
@@ -74,7 +75,7 @@ public class BPELInvokerPlugin implements IPlanBuilderProvPhaseOperationPlugin<B
     public boolean handle(final BPELPlanContext context, final AbstractOperation operation,
                           final AbstractImplementationArtifact ia,
                           final Map<AbstractParameter, Variable> param2propertyMapping,
-                          final BPELScopePhaseType phase) {
+                         Element elementToAppendTo) {
         String templateId = "";
         boolean isNodeTemplate = false;
         if (context.getNodeTemplate() != null) {
@@ -92,7 +93,7 @@ public class BPELInvokerPlugin implements IPlanBuilderProvPhaseOperationPlugin<B
 
         try {
             return this.handler.handle(context, templateId, isNodeTemplate, operation.getName(), ia.getInterfaceName(),
-                                       inputParams, new HashMap<String, Variable>(), phase);
+                                       inputParams, new HashMap<String, Variable>(),  elementToAppendTo);
         }
         catch (final Exception e) {
             e.printStackTrace();
@@ -121,7 +122,7 @@ public class BPELInvokerPlugin implements IPlanBuilderProvPhaseOperationPlugin<B
 
         try {
             return this.handler.handle(context, templateId, isNodeTemplate, operation.getName(), ia.getInterfaceName(),
-                                       inputParams, new HashMap<String, Variable>(), BPELScopePhaseType.PROVISIONING);
+                                       inputParams, new HashMap<String, Variable>(), context.getProvisioningPhaseElement());
         }
         catch (final Exception e) {
             e.printStackTrace();
@@ -147,10 +148,10 @@ public class BPELInvokerPlugin implements IPlanBuilderProvPhaseOperationPlugin<B
     public boolean handle(final BPELPlanContext context, final String templateId, final boolean isNodeTemplate,
                           final String operationName, final String interfaceName,
                           final Map<String, Variable> internalExternalPropsInput,
-                          final Map<String, Variable> internalExternalPropsOutput, final BPELScopePhaseType phase) {
+                          final Map<String, Variable> internalExternalPropsOutput,  Element elementToAppendTo) {
         try {
             return this.handler.handle(context, templateId, isNodeTemplate, operationName, interfaceName,
-                                       internalExternalPropsInput, internalExternalPropsOutput, phase);
+                                       internalExternalPropsInput, internalExternalPropsOutput, elementToAppendTo);
         }
         catch (final Exception e) {
             BPELInvokerPlugin.LOG.error("Couldn't append logic to provphase of Template: "
@@ -180,8 +181,7 @@ public class BPELInvokerPlugin implements IPlanBuilderProvPhaseOperationPlugin<B
                           final Map<String, Variable> internalExternalPropsOutput) {
         try {
             return this.handler.handle(context, operationName, interfaceName, callbackAddressVarName,
-                                       internalExternalPropsInput, internalExternalPropsOutput,
-                                       BPELScopePhaseType.PROVISIONING);
+                                       internalExternalPropsInput, internalExternalPropsOutput, context.getProvisioningPhaseElement());
         }
         catch (final Exception e) {
             BPELInvokerPlugin.LOG.error("Couldn't append logic to provphase of Template: "
@@ -210,11 +210,10 @@ public class BPELInvokerPlugin implements IPlanBuilderProvPhaseOperationPlugin<B
     public boolean handleArtifactReferenceUpload(final AbstractArtifactReference ref,
                                                  final BPELPlanContext templateContext, final PropertyVariable serverIp,
                                                  final PropertyVariable sshUser, final PropertyVariable sshKey,
-                                                 final AbstractNodeTemplate infraTemplate,
-                                                 final BPELScopePhaseType phase) {
+                                                 final AbstractNodeTemplate infraTemplate, Element elementToAppendTo) {
         try {
             return this.handler.handleArtifactReferenceUpload(ref, templateContext, serverIp, sshUser, sshKey,
-                                                              infraTemplate, phase);
+                                                              infraTemplate, elementToAppendTo);
         }
         catch (final Exception e) {
             LOG.error("Couldn't load internal files", e);
@@ -248,7 +247,7 @@ public class BPELInvokerPlugin implements IPlanBuilderProvPhaseOperationPlugin<B
 
         try {
             return this.handler.handle(context, templateId, isNodeTemplate, operation.getName(), ia.getInterfaceName(),
-                                       inputParams, outputParams, BPELScopePhaseType.PROVISIONING);
+                                       inputParams, outputParams, context.getProvisioningPhaseElement());
         }
         catch (final IOException e) {
             e.printStackTrace();
@@ -260,8 +259,7 @@ public class BPELInvokerPlugin implements IPlanBuilderProvPhaseOperationPlugin<B
     public boolean handle(final BPELPlanContext context, final AbstractOperation operation,
                           final AbstractImplementationArtifact ia,
                           final Map<AbstractParameter, Variable> param2propertyMapping,
-                          final Map<AbstractParameter, Variable> param2PropertyOutputMapping,
-                          final BPELScopePhaseType phase) {
+                          final Map<AbstractParameter, Variable> param2PropertyOutputMapping, Element elementToAppendTo) {
         final Map<String, Variable> inputParams = new HashMap<>();
         final Map<String, Variable> outputParams = new HashMap<>();
 
@@ -274,7 +272,7 @@ public class BPELInvokerPlugin implements IPlanBuilderProvPhaseOperationPlugin<B
 
         try {
             return this.handler.handle(context, operation.getName(), ia.getInterfaceName(), null, inputParams,
-                                       outputParams, phase);
+                                       outputParams, elementToAppendTo);
         }
         catch (final Exception e) {
             // TODO Auto-generated catch block
@@ -296,6 +294,10 @@ public class BPELInvokerPlugin implements IPlanBuilderProvPhaseOperationPlugin<B
                           final AbstractImplementationArtifact compensationIa,
                           final Map<AbstractParameter, Variable> compensationParam2VariableMapping) {
         // TODO Auto-generated method stub
+        
+        
+        
+        
         return false;
     }
 

--- a/org.opentosca.planbuilder.provphase.plugin.invoker/src/org/opentosca/planbuilder/provphase/plugin/invoker/bpel/handlers/BPELInvokerPluginHandler.java
+++ b/org.opentosca.planbuilder.provphase.plugin.invoker/src/org/opentosca/planbuilder/provphase/plugin/invoker/bpel/handlers/BPELInvokerPluginHandler.java
@@ -38,6 +38,7 @@ import org.osgi.framework.FrameworkUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -245,14 +246,14 @@ public class BPELInvokerPluginHandler {
 
 
         return this.handle(context, templateId, isNodeTemplate, operationName, interfaceName,
-                           internalExternalPropsInput, internalExternalPropsOutput, BPELScopePhaseType.PROVISIONING);
+                           internalExternalPropsInput, internalExternalPropsOutput, context.getProvisioningPhaseElement());
     }
 
     public boolean handle(final BPELPlanContext context, final String templateId, final boolean isNodeTemplate,
                           final String operationName, final String interfaceName,
                           final Map<String, Variable> internalExternalPropsInput,
                           final Map<String, Variable> internalExternalPropsOutput,
-                          final BPELScopePhaseType appendToPrePhase) throws IOException {
+                           Element elementToAppendTo) throws IOException {
         final File xsdFile = this.resHandler.getServiceInvokerXSDFile(context.getIdForNames());
         final File wsdlFile = this.resHandler.getServiceInvokerWSDLFile(xsdFile, context.getIdForNames());
         // register wsdls and xsd
@@ -378,19 +379,9 @@ public class BPELInvokerPluginHandler {
             messageIdInit = context.importNode(messageIdInit);
             assignNode.appendChild(messageIdInit);
 
-
-            switch (appendToPrePhase) {
-                case PRE:
-                    context.getPrePhaseElement().appendChild(assignNode);
-                    break;
-                case PROVISIONING:
-                    context.getProvisioningPhaseElement().appendChild(assignNode);
-                    break;
-                case POST:
-                    context.getPostPhaseElement().appendChild(assignNode);
-                    break;
-            }
-
+            
+            elementToAppendTo.appendChild(assignNode);
+         
         }
         catch (final SAXException e) {
             BPELInvokerPluginHandler.LOG.error("Couldn't generate DOM node for the request message assign element", e);
@@ -420,18 +411,8 @@ public class BPELInvokerPluginHandler {
             correlationSetsNode = context.importNode(correlationSetsNode);
             invokeNode.appendChild(correlationSetsNode);
 
-
-            switch (appendToPrePhase) {
-                case PRE:
-                    context.getPrePhaseElement().appendChild(invokeNode);
-                    break;
-                case PROVISIONING:
-                    context.getProvisioningPhaseElement().appendChild(invokeNode);
-                    break;
-                case POST:
-                    context.getPostPhaseElement().appendChild(invokeNode);
-                    break;
-            }
+            elementToAppendTo.appendChild(invokeNode);
+                     
         }
         catch (final SAXException e) {
             BPELInvokerPluginHandler.LOG.error("Error reading/writing XML File", e);
@@ -453,17 +434,7 @@ public class BPELInvokerPluginHandler {
             correlationSetsNode = context.importNode(correlationSetsNode);
             receiveNode.appendChild(correlationSetsNode);
 
-            switch (appendToPrePhase) {
-                case PRE:
-                    context.getPrePhaseElement().appendChild(receiveNode);
-                    break;
-                case PROVISIONING:
-                    context.getProvisioningPhaseElement().appendChild(receiveNode);
-                    break;
-                case POST:
-                    context.getPostPhaseElement().appendChild(receiveNode);
-                    break;
-            }
+            elementToAppendTo.appendChild(receiveNode);
         }
         catch (final SAXException e1) {
             BPELInvokerPluginHandler.LOG.error("Error reading/writing XML File", e1);
@@ -486,17 +457,8 @@ public class BPELInvokerPluginHandler {
             BPELInvokerPluginHandler.LOG.debug("Trying to ImportNode: " + responseAssignNode.toString());
             responseAssignNode = context.importNode(responseAssignNode);
 
-            switch (appendToPrePhase) {
-                case PRE:
-                    context.getPrePhaseElement().appendChild(responseAssignNode);
-                    break;
-                case PROVISIONING:
-                    context.getProvisioningPhaseElement().appendChild(responseAssignNode);
-                    break;
-                case POST:
-                    context.getPostPhaseElement().appendChild(responseAssignNode);
-                    break;
-            }
+            elementToAppendTo.appendChild(responseAssignNode);
+            
 
         }
         catch (final SAXException e) {
@@ -513,8 +475,7 @@ public class BPELInvokerPluginHandler {
 
     public boolean handle(final BPELPlanContext context, final String operationName, final String interfaceName,
                           final String callbackAddressVarName, final Map<String, Variable> internalExternalPropsInput,
-                          final Map<String, Variable> internalExternalPropsOutput,
-                          final BPELScopePhaseType appendToPrePhase) throws Exception {
+                          final Map<String, Variable> internalExternalPropsOutput, Element elementToAppendTo) throws Exception {
 
         // fetch "meta"-data for invoker message (e.g. csarid, nodetemplate
         // id..)
@@ -527,7 +488,7 @@ public class BPELInvokerPluginHandler {
             isNodeTemplate = false;
         }
         return this.handle(context, templateId, isNodeTemplate, operationName, interfaceName,
-                           internalExternalPropsInput, internalExternalPropsOutput, appendToPrePhase);
+                           internalExternalPropsInput, internalExternalPropsOutput, elementToAppendTo);
     }
 
     private List<String> getRunScriptParams(final AbstractNodeTemplate nodeTemplate) {
@@ -565,8 +526,7 @@ public class BPELInvokerPluginHandler {
     public boolean handleArtifactReferenceUpload(final AbstractArtifactReference ref,
                                                  final BPELPlanContext templateContext, final PropertyVariable serverIp,
                                                  final PropertyVariable sshUser, final PropertyVariable sshKey,
-                                                 final AbstractNodeTemplate infraTemplate,
-                                                 final BPELScopePhaseType appendToPrePhase) throws Exception {
+                                                 final AbstractNodeTemplate infraTemplate, Element elementToAppendTo) throws Exception {
         BPELInvokerPluginHandler.LOG.debug("Handling DA " + ref.getReference());
 
         if (Objects.isNull(serverIp)) {
@@ -602,17 +562,8 @@ public class BPELInvokerPluginHandler {
                                                               containerAPIAbsoluteURIVar.getVariableName());
             assignNode = templateContext.importNode(assignNode);
 
-            switch (appendToPrePhase) {
-                case PRE:
-                    templateContext.getPrePhaseElement().appendChild(assignNode);
-                    break;
-                case PROVISIONING:
-                    templateContext.getProvisioningPhaseElement().appendChild(assignNode);
-                    break;
-                case POST:
-                    templateContext.getPostPhaseElement().appendChild(assignNode);
-                    break;
-            }
+            elementToAppendTo.appendChild(assignNode);
+            
         }
         catch (final IOException e) {
             BPELInvokerPluginHandler.LOG.error("Couldn't read internal file", e);
@@ -645,7 +596,7 @@ public class BPELInvokerPluginHandler {
                     runScriptRequestInputParams.put(serverIp.getPropertyName(), serverIp);
                 }
                 this.handle(templateContext, infraTemplate.getId(), true, "runScript", "ContainerManagementInterface",
-                            runScriptRequestInputParams, new HashMap<String, Variable>(), appendToPrePhase);
+                            runScriptRequestInputParams, new HashMap<String, Variable>(), elementToAppendTo);
 
                 // transfer the file
                 if (transferFileInputParams.contains(serverIp.getPropertyName())) {
@@ -654,7 +605,7 @@ public class BPELInvokerPluginHandler {
                 this.handle(templateContext, infraTemplate.getId(), true,
                             Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM_TRANSFERFILE,
                             "ContainerManagementInterface", transferFileRequestInputParams,
-                            new HashMap<String, Variable>(), appendToPrePhase);
+                            new HashMap<String, Variable>(),  elementToAppendTo);
                 break;
             case Properties.OPENTOSCA_DECLARATIVE_PROPERTYNAME_VMIP:
             case Properties.OPENTOSCA_DECLARATIVE_PROPERTYNAME_RASPBIANIP:
@@ -670,7 +621,7 @@ public class BPELInvokerPluginHandler {
                 }
                 this.handle(templateContext, infraTemplate.getId(), true, "runScript",
                             Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM, runScriptRequestInputParams,
-                            new HashMap<String, Variable>(), appendToPrePhase);
+                            new HashMap<String, Variable>(),  elementToAppendTo);
 
                 // transfer the file
                 if (transferFileInputParams.contains(Properties.OPENTOSCA_DECLARATIVE_PROPERTYNAME_VMIP)) {
@@ -685,7 +636,7 @@ public class BPELInvokerPluginHandler {
                 this.handle(templateContext, infraTemplate.getId(), true,
                             Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM_TRANSFERFILE,
                             Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM, transferFileRequestInputParams,
-                            new HashMap<String, Variable>(), appendToPrePhase);
+                            new HashMap<String, Variable>(),  elementToAppendTo);
                 break;
             default:
                 return false;

--- a/org.opentosca.planbuilder.provphase.plugin.invoker/src/org/opentosca/planbuilder/provphase/plugin/invoker/bpel/handlers/BPELInvokerPluginHandler.java
+++ b/org.opentosca.planbuilder.provphase.plugin.invoker/src/org/opentosca/planbuilder/provphase/plugin/invoker/bpel/handlers/BPELInvokerPluginHandler.java
@@ -447,31 +447,14 @@ public class BPELInvokerPluginHandler {
         }
 
 
-        try {
-            Node checkForFault =
-                this.resHandler.generateBPELIfTrueThrowFaultAsNode("boolean($" + responseVariableName
-                    + "//*[local-name()=\"Param\" and namespace-uri()=\"http://siserver.org/schema\"]/*[local-name()=\"key\" and text()=\"Fault\"])",
-                                                                   new QName(
-                                                                       "http://opentosca.org/plans/invocationfault",
-                                                                       templateId + "_" + interfaceName + "_"
-                                                                           + operationName,
-                                                                       "fault" + String.valueOf(System.currentTimeMillis())), responseVariableName);
-
-            checkForFault = context.importNode(checkForFault);
-
-            elementToAppendTo.appendChild(checkForFault);
-        }
-        catch (SAXException e1) {
-            // TODO Auto-generated catch block
-            e1.printStackTrace();
-        }
+        Node responseAssignNode = null;
 
 
         // process response message
         // add assign for response
         try {
 
-            Node responseAssignNode =
+            responseAssignNode =
                 this.resHandler.generateResponseAssignAsNode(responseVariableName, OutputMessagePartName,
                                                              internalExternalPropsOutput,
                                                              "assign_" + responseVariableName, OutputMessageId,
@@ -491,6 +474,27 @@ public class BPELInvokerPluginHandler {
             return false;
         }
 
+        
+        try {
+            Node checkForFault =
+                this.resHandler.generateBPELIfTrueThrowFaultAsNode("boolean($" + responseVariableName
+                    + "//*[local-name()=\"Param\" and namespace-uri()=\"http://siserver.org/schema\"]/*[local-name()=\"key\" and text()=\"Fault\"])",
+                                                                   new QName(
+                                                                       "http://opentosca.org/plans/invocationfault",
+                                                                       templateId + "_" + interfaceName + "_"
+                                                                           + operationName,
+                                                                       "fault" + String.valueOf(System.currentTimeMillis())), responseVariableName);
+
+            checkForFault = context.importNode(checkForFault);
+            elementToAppendTo.insertBefore(checkForFault, responseAssignNode);
+            
+            //elementToAppendTo.appendChild(checkForFault);
+        }
+        catch (SAXException e1) {
+            // TODO Auto-generated catch block
+            e1.printStackTrace();
+        }
+        
         return true;
     }
 

--- a/org.opentosca.planbuilder.provphase.plugin.invoker/src/org/opentosca/planbuilder/provphase/plugin/invoker/bpel/handlers/BPELInvokerPluginHandler.java
+++ b/org.opentosca.planbuilder.provphase.plugin.invoker/src/org/opentosca/planbuilder/provphase/plugin/invoker/bpel/handlers/BPELInvokerPluginHandler.java
@@ -246,14 +246,15 @@ public class BPELInvokerPluginHandler {
 
 
         return this.handle(context, templateId, isNodeTemplate, operationName, interfaceName,
-                           internalExternalPropsInput, internalExternalPropsOutput, context.getProvisioningPhaseElement());
+                           internalExternalPropsInput, internalExternalPropsOutput,
+                           context.getProvisioningPhaseElement());
     }
 
     public boolean handle(final BPELPlanContext context, final String templateId, final boolean isNodeTemplate,
                           final String operationName, final String interfaceName,
                           final Map<String, Variable> internalExternalPropsInput,
                           final Map<String, Variable> internalExternalPropsOutput,
-                           Element elementToAppendTo) throws IOException {
+                          Element elementToAppendTo) throws IOException {
         final File xsdFile = this.resHandler.getServiceInvokerXSDFile(context.getIdForNames());
         final File wsdlFile = this.resHandler.getServiceInvokerWSDLFile(xsdFile, context.getIdForNames());
         // register wsdls and xsd
@@ -341,7 +342,7 @@ public class BPELInvokerPluginHandler {
             // of removal
             // TIP this issue theoretically happens only with the "container deployment pattern" were a hosting
             // node has the operations needed to manage a component => different termination handling for such
-            // components is needed          
+            // components is needed
             assignNode =
                 this.resHandler.generateInvokerRequestMessageInitAssignTemplateAsNode(context.getCSARFileName(),
                                                                                       context.getServiceTemplateId(),
@@ -379,9 +380,9 @@ public class BPELInvokerPluginHandler {
             messageIdInit = context.importNode(messageIdInit);
             assignNode.appendChild(messageIdInit);
 
-            
+
             elementToAppendTo.appendChild(assignNode);
-         
+
         }
         catch (final SAXException e) {
             BPELInvokerPluginHandler.LOG.error("Couldn't generate DOM node for the request message assign element", e);
@@ -412,7 +413,7 @@ public class BPELInvokerPluginHandler {
             invokeNode.appendChild(correlationSetsNode);
 
             elementToAppendTo.appendChild(invokeNode);
-                     
+
         }
         catch (final SAXException e) {
             BPELInvokerPluginHandler.LOG.error("Error reading/writing XML File", e);
@@ -445,6 +446,27 @@ public class BPELInvokerPluginHandler {
             return false;
         }
 
+
+        try {
+            Node checkForFault =
+                this.resHandler.generateBPELIfTrueThrowFaultAsNode("boolean($" + responseVariableName
+                    + "//*[local-name()=\"Param\" and namespace-uri()=\"http://siserver.org/schema\"]/*[local-name()=\"key\" and text()=\"Fault\"])",
+                                                                   new QName(
+                                                                       "http://opentosca.org/plans/invocationfault",
+                                                                       templateId + "_" + interfaceName + "_"
+                                                                           + operationName,
+                                                                       "fault" + String.valueOf(System.currentTimeMillis())), responseVariableName);
+
+            checkForFault = context.importNode(checkForFault);
+
+            elementToAppendTo.appendChild(checkForFault);
+        }
+        catch (SAXException e1) {
+            // TODO Auto-generated catch block
+            e1.printStackTrace();
+        }
+
+
         // process response message
         // add assign for response
         try {
@@ -454,11 +476,10 @@ public class BPELInvokerPluginHandler {
                                                              internalExternalPropsOutput,
                                                              "assign_" + responseVariableName, OutputMessageId,
                                                              context.getPlanResponseMessageName(), "payload");
-            BPELInvokerPluginHandler.LOG.debug("Trying to ImportNode: " + responseAssignNode.toString());
             responseAssignNode = context.importNode(responseAssignNode);
 
             elementToAppendTo.appendChild(responseAssignNode);
-            
+
 
         }
         catch (final SAXException e) {
@@ -475,7 +496,8 @@ public class BPELInvokerPluginHandler {
 
     public boolean handle(final BPELPlanContext context, final String operationName, final String interfaceName,
                           final String callbackAddressVarName, final Map<String, Variable> internalExternalPropsInput,
-                          final Map<String, Variable> internalExternalPropsOutput, Element elementToAppendTo) throws Exception {
+                          final Map<String, Variable> internalExternalPropsOutput,
+                          Element elementToAppendTo) throws Exception {
 
         // fetch "meta"-data for invoker message (e.g. csarid, nodetemplate
         // id..)
@@ -526,7 +548,8 @@ public class BPELInvokerPluginHandler {
     public boolean handleArtifactReferenceUpload(final AbstractArtifactReference ref,
                                                  final BPELPlanContext templateContext, final PropertyVariable serverIp,
                                                  final PropertyVariable sshUser, final PropertyVariable sshKey,
-                                                 final AbstractNodeTemplate infraTemplate, Element elementToAppendTo) throws Exception {
+                                                 final AbstractNodeTemplate infraTemplate,
+                                                 Element elementToAppendTo) throws Exception {
         BPELInvokerPluginHandler.LOG.debug("Handling DA " + ref.getReference());
 
         if (Objects.isNull(serverIp)) {
@@ -563,7 +586,7 @@ public class BPELInvokerPluginHandler {
             assignNode = templateContext.importNode(assignNode);
 
             elementToAppendTo.appendChild(assignNode);
-            
+
         }
         catch (final IOException e) {
             BPELInvokerPluginHandler.LOG.error("Couldn't read internal file", e);
@@ -605,7 +628,7 @@ public class BPELInvokerPluginHandler {
                 this.handle(templateContext, infraTemplate.getId(), true,
                             Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM_TRANSFERFILE,
                             "ContainerManagementInterface", transferFileRequestInputParams,
-                            new HashMap<String, Variable>(),  elementToAppendTo);
+                            new HashMap<String, Variable>(), elementToAppendTo);
                 break;
             case Properties.OPENTOSCA_DECLARATIVE_PROPERTYNAME_VMIP:
             case Properties.OPENTOSCA_DECLARATIVE_PROPERTYNAME_RASPBIANIP:
@@ -621,7 +644,7 @@ public class BPELInvokerPluginHandler {
                 }
                 this.handle(templateContext, infraTemplate.getId(), true, "runScript",
                             Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM, runScriptRequestInputParams,
-                            new HashMap<String, Variable>(),  elementToAppendTo);
+                            new HashMap<String, Variable>(), elementToAppendTo);
 
                 // transfer the file
                 if (transferFileInputParams.contains(Properties.OPENTOSCA_DECLARATIVE_PROPERTYNAME_VMIP)) {
@@ -636,7 +659,7 @@ public class BPELInvokerPluginHandler {
                 this.handle(templateContext, infraTemplate.getId(), true,
                             Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM_TRANSFERFILE,
                             Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM, transferFileRequestInputParams,
-                            new HashMap<String, Variable>(),  elementToAppendTo);
+                            new HashMap<String, Variable>(), elementToAppendTo);
                 break;
             default:
                 return false;

--- a/org.opentosca.planbuilder.provphase.plugin.invoker/src/org/opentosca/planbuilder/provphase/plugin/invoker/bpel/handlers/ResourceHandler.java
+++ b/org.opentosca.planbuilder.provphase.plugin.invoker/src/org/opentosca/planbuilder/provphase/plugin/invoker/bpel/handlers/ResourceHandler.java
@@ -17,6 +17,7 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.core.runtime.FileLocator;
+import org.opentosca.planbuilder.core.bpel.fragments.BPELProcessFragments;
 import org.opentosca.planbuilder.plugins.context.Variable;
 import org.opentosca.planbuilder.provphase.plugin.invoker.Activator;
 import org.osgi.framework.BundleContext;
@@ -41,6 +42,8 @@ public class ResourceHandler {
 
     private final DocumentBuilderFactory docFactory;
     private final DocumentBuilder docBuilder;
+    
+    private final BPELProcessFragments fragments;
 
     /**
      * Constructor
@@ -51,21 +54,7 @@ public class ResourceHandler {
         this.docFactory = DocumentBuilderFactory.newInstance();
         this.docFactory.setNamespaceAware(true);
         this.docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-
-    }
-    
-    private String loadFragmentResourceAsString(final String fileName) throws IOException {
-        final URL url = FrameworkUtil.getBundle(this.getClass()).getResource(fileName);
-        final File bpelfragmentfile = new File(FileLocator.toFileURL(url).getPath());
-        String template = FileUtils.readFileToString(bpelfragmentfile);
-        return template;
-    }
-
-    private Node transformStringToNode(String xmlString) throws SAXException, IOException {
-        final InputSource is = new InputSource();
-        is.setCharacterStream(new StringReader(xmlString));
-        final Document doc = this.docBuilder.parse(is);
-        return doc.getFirstChild();
+        this.fragments = new BPELProcessFragments();
     }
     
     private BundleContext getContext() {
@@ -93,7 +82,7 @@ public class ResourceHandler {
     public Node generateBPELIfTrueThrowFaultAsNode(final String xpath1Expr, final QName faultQName, final String faultVariableName) throws IOException,
                                                                                                     SAXException {
         final String templateString = generateBPELIfTrueThrowFaultAsString(xpath1Expr, faultQName, faultVariableName);
-        return this.transformStringToNode(templateString);
+        return this.fragments.transformStringToNode(templateString);
     }
 
     /**
@@ -108,7 +97,7 @@ public class ResourceHandler {
     public String generateBPELIfTrueThrowFaultAsString(final String xpath1Expr,
                                                        final QName faultQName, String faultVariableName) throws IOException {
         // <!-- $xpath1Expr, $faultPrefix, $faultNamespace, $faultLocalName-->
-        String bpelIfString = this.loadFragmentResourceAsString("ifFaultMessageThrowFault.xml");
+        String bpelIfString = this.fragments.loadFragmentResourceAsString("ifFaultMessageThrowFault.xml");
 
         bpelIfString = bpelIfString.replace("$xpath1Expr", xpath1Expr);
 

--- a/org.opentosca.planbuilder.type.plugin.dockercontainer/src/org/opentosca/planbuilder/type/plugin/dockercontainer/bpel/handler/BPELOpenMTCDockerContainerTypePluginHandler.java
+++ b/org.opentosca.planbuilder.type.plugin.dockercontainer/src/org/opentosca/planbuilder/type/plugin/dockercontainer/bpel/handler/BPELOpenMTCDockerContainerTypePluginHandler.java
@@ -459,7 +459,7 @@ public class BPELOpenMTCDockerContainerTypePluginHandler implements
         this.invokerPlugin.handle(context, dockerEngineNode.getId(), true,
                                   Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_DOCKERENGINE_STARTCONTAINER,
                                   Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_DOCKERENGINE, createDEInternalExternalPropsInput,
-                                  createDEInternalExternalPropsOutput, BPELScopePhaseType.PROVISIONING);
+                                  createDEInternalExternalPropsOutput, context.getProvisioningPhaseElement());
 
         return true;
     }

--- a/org.opentosca.planbuilder.type.plugin.mosquittoconnectsto/src/org/opentosca/planbuilder/type/plugin/mosquittoconnectsto/bpel/handler/BPELConnectsToPluginHandler.java
+++ b/org.opentosca.planbuilder.type.plugin.mosquittoconnectsto/src/org/opentosca/planbuilder/type/plugin/mosquittoconnectsto/bpel/handler/BPELConnectsToPluginHandler.java
@@ -181,7 +181,7 @@ public class BPELConnectsToPluginHandler implements ConnectsToTypePluginHandler<
 
         this.invokerPlugin.handle(templateContext, ubuntuTemplateId, true, "runScript",
                                   Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM, runScriptRequestInputParams,
-                                  new HashMap<String, Variable>(), BPELScopePhaseType.PROVISIONING);
+                                  new HashMap<String, Variable>(), templateContext.getProvisioningPhaseElement());
 
         return true;
     }

--- a/org.opentosca.planbuilder.type.plugin.patternbased/src/org/opentosca/planbuilder/type/plugin/patternbased/bpel/ContainerPatternBasedHandler.java
+++ b/org.opentosca.planbuilder.type.plugin.patternbased/src/org/opentosca/planbuilder/type/plugin/patternbased/bpel/ContainerPatternBasedHandler.java
@@ -13,10 +13,11 @@ import org.opentosca.planbuilder.model.tosca.AbstractNodeTemplate;
 import org.opentosca.planbuilder.model.tosca.AbstractOperation;
 import org.opentosca.planbuilder.model.tosca.AbstractRelationshipTemplate;
 import org.opentosca.planbuilder.model.utils.ModelUtils;
+import org.w3c.dom.Element;
 
 public class ContainerPatternBasedHandler extends PatternBasedHandler {
 
-    public boolean handleCreate(final BPELPlanContext context, final AbstractNodeTemplate nodeTemplate) {
+    public boolean handleCreate(final BPELPlanContext context, final AbstractNodeTemplate nodeTemplate, Element elementToAppendTo) {
 
         final AbstractNodeTemplate hostingContainer = getHostingNode(nodeTemplate);
 
@@ -25,10 +26,10 @@ public class ContainerPatternBasedHandler extends PatternBasedHandler {
 
         final Set<AbstractNodeTemplate> nodesForMatching = calculateNodesForMatching(nodeTemplate);
 
-        return invokeWithMatching(context, hostingContainer, iface, createOperation, nodesForMatching);
+        return invokeWithMatching(context, hostingContainer, iface, createOperation, nodesForMatching, elementToAppendTo);
     }
 
-    public boolean handleTerminate(final BPELPlanContext context, final AbstractNodeTemplate nodeTemplate) {
+    public boolean handleTerminate(final BPELPlanContext context, final AbstractNodeTemplate nodeTemplate, Element elementToAppendTo) {
 
         final AbstractNodeTemplate hostingContainer = getHostingNode(nodeTemplate);
 
@@ -37,7 +38,7 @@ public class ContainerPatternBasedHandler extends PatternBasedHandler {
 
         final Set<AbstractNodeTemplate> nodesForMatching = calculateNodesForMatching(nodeTemplate);
 
-        return invokeWithMatching(context, hostingContainer, iface, terminateOperation, nodesForMatching);
+        return invokeWithMatching(context, hostingContainer, iface, terminateOperation, nodesForMatching, elementToAppendTo);
     }
 
     public boolean isProvisionableByContainerPattern(final AbstractNodeTemplate nodeTemplate) {

--- a/org.opentosca.planbuilder.type.plugin.patternbased/src/org/opentosca/planbuilder/type/plugin/patternbased/bpel/LifecyclePatternBasedHandler.java
+++ b/org.opentosca.planbuilder.type.plugin.patternbased/src/org/opentosca/planbuilder/type/plugin/patternbased/bpel/LifecyclePatternBasedHandler.java
@@ -13,10 +13,11 @@ import org.opentosca.planbuilder.model.tosca.AbstractNodeTemplate;
 import org.opentosca.planbuilder.model.tosca.AbstractNodeTypeImplementation;
 import org.opentosca.planbuilder.model.tosca.AbstractOperation;
 import org.opentosca.planbuilder.model.utils.ModelUtils;
+import org.w3c.dom.Element;
 
 public class LifecyclePatternBasedHandler extends PatternBasedHandler {
 
-    public boolean handleCreate(final BPELPlanContext context, final AbstractNodeTemplate nodeTemplate) {
+    public boolean handleCreate(final BPELPlanContext context, final AbstractNodeTemplate nodeTemplate, Element elementToAppendTo) {
 
         AbstractInterface iface = this.getLifecyclePatternInterface(nodeTemplate);
 
@@ -29,23 +30,23 @@ public class LifecyclePatternBasedHandler extends PatternBasedHandler {
 
         if (((op = this.getLifecyclePatternInstallMethod(nodeTemplate)) != null)
             && hasCompleteMatching(nodesForMatching, iface, op)) {
-            result &= invokeWithMatching(context, nodeTemplate, iface, op, nodesForMatching);
+            result &= invokeWithMatching(context, nodeTemplate, iface, op, nodesForMatching,elementToAppendTo);
         }
 
         if (((op = this.getLifecyclePatternConfigureMethod(nodeTemplate)) != null)
             && hasCompleteMatching(nodesForMatching, iface, op)) {
-            result &= invokeWithMatching(context, nodeTemplate, iface, op, nodesForMatching);
+            result &= invokeWithMatching(context, nodeTemplate, iface, op, nodesForMatching,elementToAppendTo);
         }
 
         if (((op = this.getLifecyclePatternStartMethod(nodeTemplate)) != null)
             && hasCompleteMatching(nodesForMatching, iface, op)) {
-            result &= invokeWithMatching(context, nodeTemplate, iface, op, nodesForMatching);
+            result &= invokeWithMatching(context, nodeTemplate, iface, op, nodesForMatching,elementToAppendTo);
         }
 
         return result;
     }
 
-    public boolean handleTerminate(final BPELPlanContext context, final AbstractNodeTemplate nodeTemplate) {
+    public boolean handleTerminate(final BPELPlanContext context, final AbstractNodeTemplate nodeTemplate, Element elementToAppendTo) {
 
         AbstractInterface iface = this.getLifecyclePatternInterface(nodeTemplate);
 
@@ -56,12 +57,12 @@ public class LifecyclePatternBasedHandler extends PatternBasedHandler {
 
         if (((op = this.getLifecyclePatternStopMethod(nodeTemplate)) != null)
             && hasCompleteMatching(nodesForMatching, iface, op)) {
-            result &= invokeWithMatching(context, nodeTemplate, iface, op, nodesForMatching);
+            result &= invokeWithMatching(context, nodeTemplate, iface, op, nodesForMatching, elementToAppendTo);
         }
 
         if (((op = this.getLifecyclePatternUninstallMethod(nodeTemplate)) != null)
             && hasCompleteMatching(nodesForMatching, iface, op)) {
-            result &= invokeWithMatching(context, nodeTemplate, iface, op, nodesForMatching);
+            result &= invokeWithMatching(context, nodeTemplate, iface, op, nodesForMatching, elementToAppendTo);
         }
 
         return result;

--- a/org.opentosca.planbuilder.type.plugin.patternbased/src/org/opentosca/planbuilder/type/plugin/patternbased/bpel/PatternBasedHandler.java
+++ b/org.opentosca.planbuilder.type.plugin.patternbased/src/org/opentosca/planbuilder/type/plugin/patternbased/bpel/PatternBasedHandler.java
@@ -16,6 +16,7 @@ import org.opentosca.planbuilder.model.utils.ModelUtils;
 import org.opentosca.planbuilder.plugins.context.PlanContext;
 import org.opentosca.planbuilder.plugins.context.Variable;
 import org.opentosca.planbuilder.provphase.plugin.invoker.bpel.BPELInvokerPlugin;
+import org.w3c.dom.Element;
 
 public abstract class PatternBasedHandler {
 
@@ -58,11 +59,11 @@ public abstract class PatternBasedHandler {
     protected static final BPELInvokerPlugin invoker = new BPELInvokerPlugin();
 
     protected boolean invokeOperation(final BPELPlanContext context, final ConcreteOperationMatching matching,
-                                      final AbstractNodeTemplate hostingContainer) {
+                                      final AbstractNodeTemplate hostingContainer, Element elementToAppendTo) {
 
         return invoker.handle(context, hostingContainer.getId(), true, matching.operationName.getName(),
                               matching.interfaceName.getName(), transformForInvoker(matching.inputMatching),
-                              transformForInvoker(matching.outputMatching), context.getProvisioningPhaseElement());
+                              transformForInvoker(matching.outputMatching), elementToAppendTo);
     }
 
     private Map<String, Variable> transformForInvoker(final Map<AbstractParameter, Variable> map) {
@@ -73,10 +74,10 @@ public abstract class PatternBasedHandler {
 
     protected boolean invokeWithMatching(final BPELPlanContext context, final AbstractNodeTemplate nodeTemplate,
                                          final AbstractInterface iface, final AbstractOperation op,
-                                         final Set<AbstractNodeTemplate> nodesForMatching) {
+                                         final Set<AbstractNodeTemplate> nodesForMatching, Element elementToAppendTo) {
         final ConcreteOperationMatching matching =
             createConcreteOperationMatching(context, createPropertyToParameterMatching(nodesForMatching, iface, op));
-        return invokeOperation(context, matching, nodeTemplate);
+        return invokeOperation(context, matching, nodeTemplate, elementToAppendTo);
     }
 
     protected ConcreteOperationMatching createConcreteOperationMatching(final PlanContext context,

--- a/org.opentosca.planbuilder.type.plugin.patternbased/src/org/opentosca/planbuilder/type/plugin/patternbased/bpel/PatternBasedHandler.java
+++ b/org.opentosca.planbuilder.type.plugin.patternbased/src/org/opentosca/planbuilder/type/plugin/patternbased/bpel/PatternBasedHandler.java
@@ -62,7 +62,7 @@ public abstract class PatternBasedHandler {
 
         return invoker.handle(context, hostingContainer.getId(), true, matching.operationName.getName(),
                               matching.interfaceName.getName(), transformForInvoker(matching.inputMatching),
-                              transformForInvoker(matching.outputMatching), BPELScopePhaseType.PROVISIONING);
+                              transformForInvoker(matching.outputMatching), context.getProvisioningPhaseElement());
     }
 
     private Map<String, Variable> transformForInvoker(final Map<AbstractParameter, Variable> map) {

--- a/org.opentosca.planbuilder.type.plugin.ubuntuvm/src/org/opentosca/planbuilder/type/plugin/ubuntuvm/bpel/BPELUbuntuVmTypePlugin.java
+++ b/org.opentosca.planbuilder.type.plugin.ubuntuvm/src/org/opentosca/planbuilder/type/plugin/ubuntuvm/bpel/BPELUbuntuVmTypePlugin.java
@@ -315,7 +315,8 @@ public class BPELUbuntuVmTypePlugin implements IPlanBuilderTypePlugin<BPELPlanCo
                                        .startsWith(Types.openStackLiberty12NodeTypeGenerated.getLocalPart())) {
                         // bit hacky now, but until the nodeType cleanup is
                         // finished this should be enough right now
-                        return this.handler.handleTerminateWithCloudProviderInterface(templateContext, nodeTemplate);
+                        return this.handler.handleTerminateWithCloudProviderInterface(templateContext, nodeTemplate,
+                                                                                      templateContext.getProvisioningPhaseElement());
                     } else if (relation.getTarget().getType().getId().equals(Types.localHypervisor)) {
                         return this.handler.handleWithLocalCloudProviderInterface(templateContext, nodeTemplate);
                     } else {

--- a/org.opentosca.planbuilder.type.plugin.ubuntuvm/src/org/opentosca/planbuilder/type/plugin/ubuntuvm/bpel/BPELUbuntuVmTypePluginHandler.java
+++ b/org.opentosca.planbuilder.type.plugin.ubuntuvm/src/org/opentosca/planbuilder/type/plugin/ubuntuvm/bpel/BPELUbuntuVmTypePluginHandler.java
@@ -417,7 +417,7 @@ public class BPELUbuntuVmTypePluginHandler implements UbuntuVmTypePluginHandler<
     }
 
     public boolean handleTerminateWithCloudProviderInterface(final BPELPlanContext context,
-                                                             final AbstractNodeTemplate nodeTemplate) {
+                                                             final AbstractNodeTemplate nodeTemplate, Element elementToAppendTo) {
         final List<AbstractNodeTemplate> infraNodes = context.getInfrastructureNodes();
         for (final AbstractNodeTemplate infraNode : infraNodes) {
             if (org.opentosca.container.core.tosca.convention.Utils.isSupportedCloudProviderNodeType(infraNode.getType()
@@ -425,10 +425,30 @@ public class BPELUbuntuVmTypePluginHandler implements UbuntuVmTypePluginHandler<
                 // append logic to call terminateVM method on the
                 // node
 
-                return context.executeOperation(infraNode,
-                                                org.opentosca.container.core.tosca.convention.Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_CLOUDPROVIDER,
-                                                org.opentosca.container.core.tosca.convention.Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_CLOUDPROVIDER_TERMINATEVM,
-                                                null);
+                AbstractNodeTemplate ubuntuNode = context.getNodeTemplate();
+                AbstractNodeTemplate hypervisorNode = infraNode;
+
+                final Map<String, Variable> inputs = new HashMap<>();
+                final Map<String, Variable> outputs = new HashMap<>();
+
+                Variable hypervisorTenant = context.getPropertyVariable(hypervisorNode, "HypervisorTenantID");
+                Variable hypervisorEndpoint = context.getPropertyVariable(hypervisorNode, "HypervisorEndpoint");
+                Variable VMInstanceID = context.getPropertyVariable(ubuntuNode, "VMInstanceID");
+                Variable hypervisorUserName = context.getPropertyVariable(hypervisorNode, "HypervisorUserName");
+                Variable hypervisorUserPassword = context.getPropertyVariable(hypervisorNode, "HypervisorUserPassword");
+
+                inputs.put("HypervisorTenantID", hypervisorTenant);
+                inputs.put("HypervisorEndpoint", hypervisorEndpoint);
+                inputs.put("VMInstanceID", VMInstanceID);
+                inputs.put("HypervisorUserName", hypervisorUserName);
+                inputs.put("HypervisorUserPassword", hypervisorUserPassword);
+
+
+                return this.invokerOpPlugin.handle(context, hypervisorNode.getId(),true,
+                                                   org.opentosca.container.core.tosca.convention.Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_CLOUDPROVIDER_TERMINATEVM,
+                                                   org.opentosca.container.core.tosca.convention.Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_CLOUDPROVIDER,
+                                                   inputs, outputs, elementToAppendTo);
+
 
             }
         }
@@ -674,6 +694,8 @@ public class BPELUbuntuVmTypePluginHandler implements UbuntuVmTypePluginHandler<
                                     Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM_WAITFORAVAIL,
                                     Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM, startRequestInputParams,
                                     startRequestOutputParams, context.getProvisioningPhaseElement());
+        
+        this.handleTerminateWithCloudProviderInterface(context, ubuntuNodeTemplate, context.getProvisioningCompensationPhaseElement());
 
         for (final AbstractPolicy policy : nodeTemplate.getPolicies()) {
             if (policy.getType().getId().equals(this.onlyModeledPortsPolicyType)) {
@@ -1170,7 +1192,7 @@ public class BPELUbuntuVmTypePluginHandler implements UbuntuVmTypePluginHandler<
                                     Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_CLOUDPROVIDER_CREATEVM,
                                     Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_CLOUDPROVIDER,
                                     createEC2InternalExternalPropsInput, createEC2InternalExternalPropsOutput,
-                                     context.getProvisioningPhaseElement());
+                                    context.getProvisioningPhaseElement());
 
         /*
          * Check whether the SSH port is open on the VM. Doing this here removes the necessity for the other

--- a/org.opentosca.planbuilder.type.plugin.ubuntuvm/src/org/opentosca/planbuilder/type/plugin/ubuntuvm/bpel/BPELUbuntuVmTypePluginHandler.java
+++ b/org.opentosca.planbuilder.type.plugin.ubuntuvm/src/org/opentosca/planbuilder/type/plugin/ubuntuvm/bpel/BPELUbuntuVmTypePluginHandler.java
@@ -411,7 +411,7 @@ public class BPELUbuntuVmTypePluginHandler implements UbuntuVmTypePluginHandler<
 
         this.invokerOpPlugin.handle(context, ubuntuNodeTemplate.getId(), true, "start", "InterfaceUbuntu",
                                     startRequestInputParams, new HashMap<String, Variable>(),
-                                    BPELScopePhaseType.PROVISIONING);
+                                    context.getProvisioningPhaseElement());
 
         return true;
     }
@@ -654,7 +654,7 @@ public class BPELUbuntuVmTypePluginHandler implements UbuntuVmTypePluginHandler<
                                     Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_CLOUDPROVIDER_CREATEVM,
                                     Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_CLOUDPROVIDER,
                                     createEC2InternalExternalPropsInput, createEC2InternalExternalPropsOutput,
-                                    BPELScopePhaseType.PROVISIONING);
+                                    context.getProvisioningPhaseElement());
 
         /*
          * Check whether the SSH port is open on the VM. Doing this here removes the necessity for the other
@@ -673,7 +673,7 @@ public class BPELUbuntuVmTypePluginHandler implements UbuntuVmTypePluginHandler<
         this.invokerOpPlugin.handle(context, ubuntuNodeTemplate.getId(), true,
                                     Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM_WAITFORAVAIL,
                                     Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM, startRequestInputParams,
-                                    startRequestOutputParams, BPELScopePhaseType.PROVISIONING);
+                                    startRequestOutputParams, context.getProvisioningPhaseElement());
 
         for (final AbstractPolicy policy : nodeTemplate.getPolicies()) {
             if (policy.getType().getId().equals(this.onlyModeledPortsPolicyType)) {
@@ -744,7 +744,7 @@ public class BPELUbuntuVmTypePluginHandler implements UbuntuVmTypePluginHandler<
         this.invokerOpPlugin.handle(context, ubuntuNodeTemplate.getId(), true,
                                     Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM_RUNSCRIPT,
                                     Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM, startRequestInputParams,
-                                    startRequestOutputParams, BPELScopePhaseType.PROVISIONING);
+                                    startRequestOutputParams, context.getProvisioningPhaseElement());
     }
 
     private List<Variable> fetchModeledPortsOfInfrastructure(final PlanContext context,
@@ -943,7 +943,7 @@ public class BPELUbuntuVmTypePluginHandler implements UbuntuVmTypePluginHandler<
                                     Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_DOCKERENGINE_STARTCONTAINER,
                                     Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_DOCKERENGINE,
                                     createDEInternalExternalPropsInput, createDEInternalExternalPropsOutput,
-                                    BPELScopePhaseType.PROVISIONING);
+                                    context.getProvisioningPhaseElement());
 
         /*
          * Check whether the SSH port is open on the VM. Doing this here removes the necessity for the other
@@ -961,7 +961,7 @@ public class BPELUbuntuVmTypePluginHandler implements UbuntuVmTypePluginHandler<
         this.invokerOpPlugin.handle(context, ubuntuNodeTemplate.getId(), true,
                                     Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM_WAITFORAVAIL,
                                     Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM, startRequestInputParams,
-                                    startRequestOutputParams, BPELScopePhaseType.PROVISIONING);
+                                    startRequestOutputParams, context.getProvisioningPhaseElement());
 
         return true;
     }
@@ -1170,7 +1170,7 @@ public class BPELUbuntuVmTypePluginHandler implements UbuntuVmTypePluginHandler<
                                     Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_CLOUDPROVIDER_CREATEVM,
                                     Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_CLOUDPROVIDER,
                                     createEC2InternalExternalPropsInput, createEC2InternalExternalPropsOutput,
-                                    BPELScopePhaseType.PROVISIONING);
+                                     context.getProvisioningPhaseElement());
 
         /*
          * Check whether the SSH port is open on the VM. Doing this here removes the necessity for the other
@@ -1188,7 +1188,7 @@ public class BPELUbuntuVmTypePluginHandler implements UbuntuVmTypePluginHandler<
         this.invokerOpPlugin.handle(context, ubuntuNodeTemplate.getId(), true,
                                     Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM_WAITFORAVAIL,
                                     Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_OPERATINGSYSTEM, startRequestInputParams,
-                                    startRequestOutputParams, BPELScopePhaseType.PROVISIONING);
+                                    startRequestOutputParams, context.getProvisioningPhaseElement());
 
         return true;
     }

--- a/org.opentosca.planbuilder/src/org/opentosca/planbuilder/plugins/artifactbased/IPlanBuilderCompensationOperationPlugin.java
+++ b/org.opentosca.planbuilder/src/org/opentosca/planbuilder/plugins/artifactbased/IPlanBuilderCompensationOperationPlugin.java
@@ -11,23 +11,81 @@ import org.opentosca.planbuilder.plugins.context.Variable;
 
 public interface IPlanBuilderCompensationOperationPlugin<T extends PlanContext>
                                                         extends IPlanBuilderProvPhaseParamOperationPlugin<T> {
-    
+
+
+    /**
+     * Create BPEL code to invoke given method and additionally add compensation logic
+     * 
+     * @param context the plan context for the plugin
+     * @param operation the operation for that this plugin should generate invocation logic
+     * @param ia the implementation artifact of the given operation
+     * @param param2propertyMapping a mapping from operation parameters to variables
+     * @param compensationOperation the operation which compensates the given operation
+     * @param compensationIa the implementation artifact of the compensation operation
+     * @param compensationParam2VariableMapping a mapping from compensation operation parameters to
+     *        variables
+     * @return true iff generating invocation logic was successful
+     */
     public boolean handle(T context, AbstractOperation operation, AbstractImplementationArtifact ia,
                           Map<AbstractParameter, Variable> param2propertyMapping,
                           AbstractOperation compensationOperation, AbstractImplementationArtifact compensationIa,
                           Map<AbstractParameter, Variable> compensationParam2VariableMapping);
 
+
+    /**
+     * Create BPEL code to invoke given method and additionally add compensation logic
+     * 
+     * @param context the plan context for the plugin
+     * @param operation the operation for that this plugin should generate invocation logic
+     * @param ia the implementation artifact of the given operation
+     * @param param2propertyMapping a mapping from operation parameters to variables
+     * @param compensationOperation the operation which compensates the given operation
+     * @param compensationIa the implementation artifact of the compensation operation
+     * @param compensationParam2VariableMapping a mapping from compensation operation parameters to
+     *        variables
+     * @param phase determines to which phase of the scope the operation logic should be added to
+     * @return true iff generating invocation logic was successful
+     */
     public boolean handle(T context, AbstractOperation operation, AbstractImplementationArtifact ia,
                           Map<AbstractParameter, Variable> param2propertyMapping,
                           AbstractOperation compensationOperation, AbstractImplementationArtifact compensationIa,
                           Map<AbstractParameter, Variable> compensationParam2VariableMapping, BPELScopePhaseType phase);
 
+    /**
+     * Create BPEL code to invoke given method and additionally add compensation logic
+     * 
+     * @param context the plan context for the plugin
+     * @param operation the operation for that this plugin should generate invocation logic
+     * @param ia the implementation artifact of the given operation
+     * @param param2propertyMapping a mapping from operation parameters to variables
+     * @param param2PropertyOutputMapping a mapping from operation output parameters to variables
+     * @param compensationOperation the operation which compensates the given operation
+     * @param compensationIa the implementation artifact of the compensation operation
+     * @param compensationParam2VariableMapping a mapping from compensation operation parameters to
+     *        variables
+     * @return true iff generating invocation logic was successful
+     */
     public boolean handle(T context, AbstractOperation operation, AbstractImplementationArtifact ia,
                           Map<AbstractParameter, Variable> param2propertyMapping,
                           Map<AbstractParameter, Variable> param2PropertyOutputMapping,
                           AbstractOperation compensationOperation, AbstractImplementationArtifact compensationIa,
                           Map<AbstractParameter, Variable> compensationParam2VariableMapping);
 
+    /**
+     * Create BPEL code to invoke given method and additionally add compensation logic
+     * 
+     * @param context the plan context for the plugin
+     * @param operation the operation for that this plugin should generate invocation logic
+     * @param ia the implementation artifact of the given operation
+     * @param param2propertyMapping a mapping from operation parameters to variables
+     * @param param2PropertyOutputMapping a mapping from operation output parameters to variables
+     * @param compensationOperation the operation which compensates the given operation
+     * @param compensationIa the implementation artifact of the compensation operation
+     * @param compensationParam2VariableMapping a mapping from compensation operation parameters to
+     *        variables
+     * @param phase determines to which phase of the scope the operation logic should be added to
+     * @return true iff generating invocation logic was successful
+     */
     public boolean handle(T context, AbstractOperation operation, AbstractImplementationArtifact ia,
                           Map<AbstractParameter, Variable> param2propertyMapping,
                           Map<AbstractParameter, Variable> param2PropertyOutputMapping,

--- a/org.opentosca.planbuilder/src/org/opentosca/planbuilder/plugins/artifactbased/IPlanBuilderProvPhaseParamOperationPlugin.java
+++ b/org.opentosca.planbuilder/src/org/opentosca/planbuilder/plugins/artifactbased/IPlanBuilderProvPhaseParamOperationPlugin.java
@@ -2,12 +2,12 @@ package org.opentosca.planbuilder.plugins.artifactbased;
 
 import java.util.Map;
 
-import org.opentosca.planbuilder.model.plan.bpel.BPELScope.BPELScopePhaseType;
 import org.opentosca.planbuilder.model.tosca.AbstractImplementationArtifact;
 import org.opentosca.planbuilder.model.tosca.AbstractOperation;
 import org.opentosca.planbuilder.model.tosca.AbstractParameter;
 import org.opentosca.planbuilder.plugins.context.PlanContext;
 import org.opentosca.planbuilder.plugins.context.Variable;
+import org.w3c.dom.Element;
 
 /**
  *
@@ -39,7 +39,7 @@ public interface IPlanBuilderProvPhaseParamOperationPlugin<T extends PlanContext
                           Map<AbstractParameter, Variable> param2propertyMapping);
 
     public boolean handle(T context, AbstractOperation operation, AbstractImplementationArtifact ia,
-                          Map<AbstractParameter, Variable> param2propertyMapping, BPELScopePhaseType phase);
+                          Map<AbstractParameter, Variable> param2propertyMapping, Element elementToAppendTo);
 
     public boolean handle(T context, AbstractOperation operation, AbstractImplementationArtifact ia,
                           Map<AbstractParameter, Variable> param2propertyMapping,
@@ -47,6 +47,6 @@ public interface IPlanBuilderProvPhaseParamOperationPlugin<T extends PlanContext
 
     public boolean handle(T context, AbstractOperation operation, AbstractImplementationArtifact ia,
                           Map<AbstractParameter, Variable> param2propertyMapping,
-                          Map<AbstractParameter, Variable> param2PropertyOutputMapping, BPELScopePhaseType phase);
+                          Map<AbstractParameter, Variable> param2PropertyOutputMapping, Element elementToAppendTo);
 
 }


### PR DESCRIPTION
#### Short Description
Enables compensation of tasks in plans, e.g., creating a VM and if some error occurs, such as, not being able to start a docker contain on it, it terminates the VM again.

#### Proposed Changes
Add compensation handlers to the generated BPEL plans that revert already finished work.

#### Info
  Have a look at this pull request as well: https://github.com/OpenTOSCA/tosca-definitions-internal/pull/56 , it adds a CSAR for testing the compensation feature
