### PR TITLE
adds feature to control whether the container deletes IA files

### DIFF
--- a/org.opentosca.bus.management.invocation.plugin.script/src/org/opentosca/bus/management/invocation/plugin/script/ManagementBusInvocationPluginScript.java
+++ b/org.opentosca.bus.management.invocation.plugin.script/src/org/opentosca/bus/management/invocation/plugin/script/ManagementBusInvocationPluginScript.java
@@ -257,9 +257,11 @@ public class ManagementBusInvocationPluginScript implements IManagementBusInvoca
                                 artifactTypeSpecificCommand.replace(ManagementBusInvocationPluginScript.PLACEHOLDER_DA_INPUT_PARAMETER,
                                                                     createParamsString(params));
 
-                            // delete the uploaded file on the remote site to save resources
-                            final String deleteFileCommand = "; rm -f " + targetFilePath;
-                            artifactTypeSpecificCommand = artifactTypeSpecificCommand + deleteFileCommand;
+                            if (!Boolean.valueOf(Settings.OPENTOSCA_ENGINE_IA_KEEPFILES)) {                                
+                                // delete the uploaded file on the remote site to save resources
+                                final String deleteFileCommand = "; rm -f " + targetFilePath;
+                                artifactTypeSpecificCommand = artifactTypeSpecificCommand + deleteFileCommand;
+                            }
 
                             ManagementBusInvocationPluginScript.LOG.debug("Final command for the script execution: {}",
                                                                           artifactTypeSpecificCommand);
@@ -273,10 +275,13 @@ public class ManagementBusInvocationPluginScript implements IManagementBusInvoca
                             addOutputParametersToResultMap(resultMap, result, outputParameters);
                         }
 
-                        // remove the created directories
-                        ManagementBusInvocationPluginScript.LOG.debug("Deleting directories...");
-                        final String deleteDirsCommand = "find " + targetBasePath + " -empty -type d -delete";
-                        runScript(deleteDirsCommand, headers);
+                        if (!Boolean.valueOf(Settings.OPENTOSCA_ENGINE_IA_KEEPFILES)) {
+                            // remove the created directories
+                            ManagementBusInvocationPluginScript.LOG.debug("Deleting directories...");
+                            final String deleteDirsCommand = "find " + targetBasePath + " -empty -type d -delete";
+                            runScript(deleteDirsCommand, headers);
+                        }
+                        
 
                         ManagementBusInvocationPluginScript.LOG.debug("All artifacts are executed. Returning result to the Management Bus...");
 

--- a/org.opentosca.container.core/src/org/opentosca/container/core/common/Settings.java
+++ b/org.opentosca.container.core/src/org/opentosca/container/core/common/Settings.java
@@ -46,6 +46,9 @@ public class Settings {
     
     public final static String OPENTOSCA_BUS_MANAGEMENT_MOCK =
         System.getProperty("org.opentosca.bus.management.mocking", "false");
+    
+    public final static String OPENTOSCA_ENGINE_IA_KEEPFILES =
+        System.getProperty("org.opentosca.engine.ia.keepfiles", "false");
 
     public final static String OPENTOSCA_COLLABORATION_MODE =
         System.getProperty("org.opentosca.container.collaboration.mode", "false");

--- a/org.opentosca.container.core/src/org/opentosca/container/core/engine/impl/ToscaEngineServiceImpl.java
+++ b/org.opentosca.container.core/src/org/opentosca/container/core/engine/impl/ToscaEngineServiceImpl.java
@@ -1605,7 +1605,7 @@ public class ToscaEngineServiceImpl implements IToscaEngineService {
         // if there are DeploymentArtifacts
         if (nodeTypeImplementation != null && nodeTypeImplementation.getDeploymentArtifacts() != null) {
 
-            nodeTypeImplementation.getDeploymentArtifacts().getDeploymentArtifact().stream()
+            return nodeTypeImplementation.getDeploymentArtifacts().getDeploymentArtifact().stream()
                                   .filter(da -> da.getName().equals(deploymentArtifactName)).findFirst()
                                   .map(da -> da.getArtifactRef()).orElse(null);
         }
@@ -1924,6 +1924,8 @@ public class ToscaEngineServiceImpl implements IToscaEngineService {
     private Optional<TImplementationArtifact> getImplementationArtifactForName(final CSARID csarID,
                                                                                final QName typeImplementationID,
                                                                                final String implementationArtifactName) {
+        
+        LOG.warn("Searching IA " + implementationArtifactName);
 
         return getIAsOfType(csarID, typeImplementationID).stream()
                                                          .filter((ia) -> ia.getName()
@@ -1954,7 +1956,7 @@ public class ToscaEngineServiceImpl implements IToscaEngineService {
                                                                                .filter(impl -> impl != null
                                                                                    && impl.getImplementationArtifacts() != null
                                                                                    && impl.getImplementationArtifacts()
-                                                                                          .getImplementationArtifact() != null)
+                                                                                          .getImplementationArtifact() != null && impl.getName() != null)
                                                                                .flatMap(impl -> impl.getImplementationArtifacts()
                                                                                                     .getImplementationArtifact()
                                                                                                     .stream())

--- a/org.opentosca.container.product/config.ini
+++ b/org.opentosca.container.product/config.ini
@@ -1,30 +1,30 @@
 # Container Configuration
 # Your external IP address, e.g. 129.69.214.56
-org.opentosca.container.hostname=192.168.2.104
+org.opentosca.container.hostname=localhost
 org.opentosca.container.port=1337
 
 # IA Engine Configuration (endpoint and credentials)
-org.opentosca.container.engine.ia.hostname=192.168.2.104
+org.opentosca.container.engine.ia.hostname=localhost
 org.opentosca.container.engine.ia.port=8090
-org.opentosca.container.engine.ia.plugin.tomcat.url=http://192.168.2.104:8090
+org.opentosca.container.engine.ia.plugin.tomcat.url=http://localhost:8090
 org.opentosca.container.engine.ia.plugin.tomcat.username=admin
 org.opentosca.container.engine.ia.plugin.tomcat.password=admin
 
 # BPEL Plan Engine Configuration (endpoint and credentials)
 org.opentosca.container.engine.plan.plugin.bpel.engine=ODE
-org.opentosca.container.engine.plan.plugin.bpel.url=http://192.168.2.104:9763/ode
+org.opentosca.container.engine.plan.plugin.bpel.url=http://localhost:9763/ode
 org.opentosca.container.engine.plan.plugin.bpel.username=admin
 org.opentosca.container.engine.plan.plugin.bpel.password=admin
-org.opentosca.container.engine.plan.plugin.bpel.services.url=http://192.168.2.104:9763/ode/processes
+org.opentosca.container.engine.plan.plugin.bpel.services.url=http://localhost:9763/ode/processes
 
 # BPMN Plan Engine Configuration (endpoint and credentials)
 org.opentosca.container.engine.plan.plugin.bpmn.engine=Camunda
-org.opentosca.container.engine.plan.plugin.bpmn.url=http://192.168.2.104:8092/engine-rest
+org.opentosca.container.engine.plan.plugin.bpmn.url=http://localhost:8092/engine-rest
 org.opentosca.container.engine.plan.plugin.bpmn.username=admin
 org.opentosca.container.engine.plan.plugin.bpmn.password=admin
 
 # Container Model Repository (Winery)
-org.opentosca.container.connector.winery.url=http://192.168.2.104:8081/winery
+org.opentosca.container.connector.winery.url=http://localhost:8081/winery
 
 # Local MQTT broker
 org.opentosca.container.broker.mqtt.port=1883

--- a/org.opentosca.container.product/config.ini
+++ b/org.opentosca.container.product/config.ini
@@ -1,30 +1,30 @@
 # Container Configuration
 # Your external IP address, e.g. 129.69.214.56
-org.opentosca.container.hostname=localhost
+org.opentosca.container.hostname=192.168.2.104
 org.opentosca.container.port=1337
 
 # IA Engine Configuration (endpoint and credentials)
-org.opentosca.container.engine.ia.hostname=localhost
+org.opentosca.container.engine.ia.hostname=192.168.2.104
 org.opentosca.container.engine.ia.port=8090
-org.opentosca.container.engine.ia.plugin.tomcat.url=http://localhost:8090
+org.opentosca.container.engine.ia.plugin.tomcat.url=http://192.168.2.104:8090
 org.opentosca.container.engine.ia.plugin.tomcat.username=admin
 org.opentosca.container.engine.ia.plugin.tomcat.password=admin
 
 # BPEL Plan Engine Configuration (endpoint and credentials)
 org.opentosca.container.engine.plan.plugin.bpel.engine=ODE
-org.opentosca.container.engine.plan.plugin.bpel.url=http://localhost:9763/ode
+org.opentosca.container.engine.plan.plugin.bpel.url=http://192.168.2.104:9763/ode
 org.opentosca.container.engine.plan.plugin.bpel.username=admin
 org.opentosca.container.engine.plan.plugin.bpel.password=admin
-org.opentosca.container.engine.plan.plugin.bpel.services.url=http://localhost:9763/ode/processes
+org.opentosca.container.engine.plan.plugin.bpel.services.url=http://192.168.2.104:9763/ode/processes
 
 # BPMN Plan Engine Configuration (endpoint and credentials)
 org.opentosca.container.engine.plan.plugin.bpmn.engine=Camunda
-org.opentosca.container.engine.plan.plugin.bpmn.url=http://localhost:8092/engine-rest
+org.opentosca.container.engine.plan.plugin.bpmn.url=http://192.168.2.104:8092/engine-rest
 org.opentosca.container.engine.plan.plugin.bpmn.username=admin
 org.opentosca.container.engine.plan.plugin.bpmn.password=admin
 
 # Container Model Repository (Winery)
-org.opentosca.container.connector.winery.url=http://localhost:8081/winery
+org.opentosca.container.connector.winery.url=http://192.168.2.104:8081/winery
 
 # Local MQTT broker
 org.opentosca.container.broker.mqtt.port=1883
@@ -39,3 +39,4 @@ org.opentosca.container.collaboration.ports=
 # Testing
 org.opentosca.deployment.tests=false
 org.opentosca.bus.management.mocking=false
+org.opentosca.engine.ia.keepfiles=true


### PR DESCRIPTION
Some IAs are uploaded to certain resources, such as, scripts to VMs. With this feature it can be controlled whether the container should remove or keep those files on the VM, e.g., for debugging purposes