### PR TITLE
adds feature to set the state of node and relation instances to failed when errors occur

### DIFF
--- a/org.opentosca.bus.management.service.impl/src/org/opentosca/bus/management/service/impl/ManagementBusServiceImpl.java
+++ b/org.opentosca.bus.management.service.impl/src/org/opentosca/bus/management/service/impl/ManagementBusServiceImpl.java
@@ -139,20 +139,9 @@ public class ManagementBusServiceImpl implements IManagementBusService {
                 long waitTime = System.currentTimeMillis() + 1000;
                 while (System.currentTimeMillis() < waitTime) {
                 }
-
-                // if some param has fault as a value we generate a fault response
-                final Object params = message.getBody();
-                if (params != null && params instanceof HashMap && ((HashMap) params).values().contains("fault")) {                    
-                    respondViaFault(exchange, csarID, serviceTemplateID, nodeTemplateID, neededInterface,
-                                    neededOperation);
-
-                } else {
-                    // else responde via some mock values
-                    respondViaMocking(exchange, csarID, serviceTemplateID, nodeTemplateID, neededInterface,
-                                      neededOperation);
-                }
-
-
+                         
+                respondViaMocking(exchange, message,  csarID, serviceTemplateID, nodeTemplateID, neededInterface,
+                                      neededOperation);               
 
             } else {
                 this.invokeIA(exchange, csarID, serviceTemplateID, serviceTemplateInstanceID, nodeTemplateID,
@@ -181,9 +170,11 @@ public class ManagementBusServiceImpl implements IManagementBusService {
         }
     }
 
-    private void respondViaFault(final Exchange exchange, final CSARID csarID, final QName serviceTemplateID,
-                                 final String nodeTemplateID, final String neededInterface,
-                                 final String neededOperation) {
+    private void respondViaMocking(final Exchange exchange,Message message,  final CSARID csarID, final QName serviceTemplateID,
+                                   final String nodeTemplateID, final String neededInterface,
+                                   final String neededOperation) {
+        
+        
 
         final List<String> outputParams =
             ServiceHandler.toscaEngineService.getOutputParametersOfTypeOperation(csarID,
@@ -197,28 +188,10 @@ public class ManagementBusServiceImpl implements IManagementBusService {
         for (final String outputParam : outputParams) {
             responseMap.put(outputParam, "managementBusMockValue");
         }
-        responseMap.put("Fault", "managementBusMockFaultValue");
-
-        exchange.getIn().setBody(responseMap);
-
-        handleResponse(exchange);
-    }
-
-    private void respondViaMocking(final Exchange exchange, final CSARID csarID, final QName serviceTemplateID,
-                                   final String nodeTemplateID, final String neededInterface,
-                                   final String neededOperation) {
-
-        final List<String> outputParams =
-            ServiceHandler.toscaEngineService.getOutputParametersOfTypeOperation(csarID,
-                                                                                 ServiceHandler.toscaEngineService.getNodeTypeOfNodeTemplate(csarID,
-                                                                                                                                             serviceTemplateID,
-                                                                                                                                             nodeTemplateID),
-                                                                                 neededInterface, neededOperation);
-
-        final HashMap<String, String> responseMap = new HashMap<>();
-
-        for (final String outputParam : outputParams) {
-            responseMap.put(outputParam, "managementBusMockValue");
+        
+        final Object params = message.getBody();
+        if (params != null && params instanceof HashMap && ((HashMap) params).values().contains("fault")) {                    
+            responseMap.put("Fault", "managementBusMockFaultValue");
         }
 
         exchange.getIn().setBody(responseMap);

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/context/BPELPlanContext.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/context/BPELPlanContext.java
@@ -655,6 +655,14 @@ public class BPELPlanContext extends PlanContext {
     public Element getProvisioningCompensationPhaseElement() {
         return this.templateBuildPlan.getBpelCompensationHandlerScope().getBpelSequenceProvisioningPhaseElement();
     }
+    
+    /**
+     * Returns a BPEL sequence element which is used as the main fault handler sequence of this scope
+     * @return a DOM Element which is a BPEL sequence activity
+     */
+    public Element getProvisioningFaultHandlerPhaseElement() {
+        return this.templateBuildPlan.getBpelFaultHandlerScope().getBpelSequenceProvisioningPhaseElement();
+    }
 
     /**
      * Returns the RelationshipTemplate this context handles

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/handlers/BPELFinalizer.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/handlers/BPELFinalizer.java
@@ -152,6 +152,7 @@ public class BPELFinalizer {
 
         for (final BPELScope templateBuildPlan : buildPlan.getTemplateBuildPlans()) {
             this.finalizeBPELScope(buildPlan, templateBuildPlan);
+            this.finalizeBPELScope(buildPlan, templateBuildPlan.getBpelFaultHandlerScope());
             this.finalizeBPELScope(buildPlan, templateBuildPlan.getBpelCompensationHandlerScope());
         }
 

--- a/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/handlers/BPELPlanHandler.java
+++ b/org.opentosca.planbuilder.core.bpel/src/org/opentosca/planbuilder/core/bpel/handlers/BPELPlanHandler.java
@@ -1005,6 +1005,10 @@ public class BPELPlanHandler {
                 plan.addTemplateBuildPlan(newEmpty3SequenceScopeBPELActivity);
                 abstract2bpelMap.put(ntActivity, newEmpty3SequenceScopeBPELActivity);
 
+                final BPELScope newFaultHandlerScope =
+                    this.bpelScopeHandler.createTemplateBuildPlan(ntActivity, plan, "fault");               
+                newEmpty3SequenceScopeBPELActivity.setBpelFaultHandlerScope(newFaultHandlerScope);
+                
                 final BPELScope newCompensationHandlerScope =
                     this.bpelScopeHandler.createTemplateBuildPlan(ntActivity, plan, "compensation");               
                 newEmpty3SequenceScopeBPELActivity.setBpelCompensationHandlerScope(newCompensationHandlerScope);
@@ -1013,6 +1017,10 @@ public class BPELPlanHandler {
                 newEmpty3SequenceScopeBPELActivity = this.bpelScopeHandler.createTemplateBuildPlan(rtActivity, plan, "");
                 plan.addTemplateBuildPlan(newEmpty3SequenceScopeBPELActivity);
                 abstract2bpelMap.put(rtActivity, newEmpty3SequenceScopeBPELActivity);
+                
+                final BPELScope newFaultHandlerScope =
+                    this.bpelScopeHandler.createTemplateBuildPlan(rtActivity, plan, "fault");               
+                newEmpty3SequenceScopeBPELActivity.setBpelFaultHandlerScope(newFaultHandlerScope);
 
                 final BPELScope newCompensationHandlerScope =
                     this.bpelScopeHandler.createTemplateBuildPlan(rtActivity, plan, "compensation");

--- a/org.opentosca.planbuilder.model/src/org/opentosca/planbuilder/model/plan/bpel/BPELScope.java
+++ b/org.opentosca.planbuilder.model/src/org/opentosca/planbuilder/model/plan/bpel/BPELScope.java
@@ -298,9 +298,11 @@ public class BPELScope{
      */
     public void setBpelFaultHandlerScope(BPELScope bpelFaultScope) {
         this.bpelFaultScope = bpelFaultScope;        
-        Element compensationHandlerElement = this.buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "faultHandler");                
-        compensationHandlerElement.appendChild(this.bpelFaultScope.getBpelScopeElement());        
-        this.bpelScopeElement.insertBefore(compensationHandlerElement, this.bpelMainSequenceElement);        
+        Element faultHandlersElement = this.buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "faultHandlers");
+        Element catchAllElement = this.buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "catchAll");
+        catchAllElement.appendChild(this.bpelFaultScope.getBpelScopeElement());
+        faultHandlersElement.appendChild(catchAllElement);
+        this.bpelScopeElement.insertBefore(faultHandlersElement, this.bpelMainSequenceElement);        
     }
     
 

--- a/org.opentosca.planbuilder.model/src/org/opentosca/planbuilder/model/plan/bpel/BPELScope.java
+++ b/org.opentosca.planbuilder.model/src/org/opentosca/planbuilder/model/plan/bpel/BPELScope.java
@@ -1,8 +1,11 @@
 package org.opentosca.planbuilder.model.plan.bpel;
 
+import java.util.Map;
+
 import org.opentosca.planbuilder.model.plan.AbstractActivity;
 import org.opentosca.planbuilder.model.plan.ActivityType;
 import org.opentosca.planbuilder.model.tosca.AbstractNodeTemplate;
+import org.opentosca.planbuilder.model.tosca.AbstractOperation;
 import org.opentosca.planbuilder.model.tosca.AbstractRelationshipTemplate;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -50,6 +53,10 @@ public class BPELScope{
 
 
     private BPELScope bpelCompensationScope;
+    private BPELScope bpelFaultScope;
+    
+    private Map<AbstractOperation, AbstractOperation> usedOperations;
+
 
     private AbstractNodeTemplate nodeTemplate = null;
     private AbstractRelationshipTemplate relationshipTemplate = null;
@@ -178,7 +185,7 @@ public class BPELScope{
     /**
      * Sets the BPEL PartnerLinks element of this TemplateBuildPlan
      *
-     * @param bpelPartnerLinks a DOM Element
+     * @param bpelPartnerLinks a DOM Element 
      */
     public void setBpelPartnerLinks(final Element bpelPartnerLinks) {
         this.bpelPartnerLinks = bpelPartnerLinks;
@@ -277,6 +284,24 @@ public class BPELScope{
         this.bpelScopeElement.insertBefore(compensationHandlerElement, this.bpelMainSequenceElement);        
     }
 
+    /**
+     * Returns the scope containing the faul handling activities of this scope
+     * @return
+     */
+    public BPELScope getBpelFaultHandlerScope() {
+        return this.bpelFaultScope;
+    }
+    
+    /**
+     * Sets the scope as the fault handler of this scope 
+     * @param bpelFaultScope a BPEL DOM Element with fault handler
+     */
+    public void setBpelFaultHandlerScope(BPELScope bpelFaultScope) {
+        this.bpelFaultScope = bpelFaultScope;        
+        Element compensationHandlerElement = this.buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "faultHandler");                
+        compensationHandlerElement.appendChild(this.bpelFaultScope.getBpelScopeElement());        
+        this.bpelScopeElement.insertBefore(compensationHandlerElement, this.bpelMainSequenceElement);        
+    }
     
 
     /**

--- a/org.opentosca.planbuilder.model/src/org/opentosca/planbuilder/model/plan/bpel/BPELScope.java
+++ b/org.opentosca.planbuilder.model/src/org/opentosca/planbuilder/model/plan/bpel/BPELScope.java
@@ -297,11 +297,13 @@ public class BPELScope{
      * @param bpelFaultScope a BPEL DOM Element with fault handler
      */
     public void setBpelFaultHandlerScope(BPELScope bpelFaultScope) {
-        this.bpelFaultScope = bpelFaultScope;        
+        this.bpelFaultScope = bpelFaultScope;
+        Element rethrowElement = this.buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "rethrow");
+        bpelFaultScope.getBpelSequencePostPhaseElement().appendChild(rethrowElement);
         Element faultHandlersElement = this.buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "faultHandlers");
         Element catchAllElement = this.buildPlan.getBpelDocument().createElementNS(BPELPlan.bpelNamespace, "catchAll");
         catchAllElement.appendChild(this.bpelFaultScope.getBpelScopeElement());
-        faultHandlersElement.appendChild(catchAllElement);
+        faultHandlersElement.appendChild(catchAllElement);                
         this.bpelScopeElement.insertBefore(faultHandlersElement, this.bpelMainSequenceElement);        
     }
     

--- a/org.opentosca.planbuilder.postphase.plugin.instancedata/src/org/opentosca/planbuilder/postphase/plugin/instancedata/bpel/Handler.java
+++ b/org.opentosca.planbuilder.postphase.plugin.instancedata/src/org/opentosca/planbuilder/postphase/plugin/instancedata/bpel/Handler.java
@@ -933,7 +933,7 @@ public class Handler {
     
     private void appendFailedStateToCompensationHandler(BPELPlanContext context, String nodeInstanceURLVarName) {
         String stateVarName = this.createStateVar(context, context.getTemplateId());
-        this.appendStateUpdateAsChild(context, nodeInstanceURLVarName, stateVarName, "FAILED", context.getProvisioningCompensationPhaseElement());                
+        this.appendStateUpdateAsChild(context, nodeInstanceURLVarName, stateVarName, "FAILED", context.getProvisioningFaultHandlerPhaseElement());                
     }
 
     private void appendStateUpdateToPrePhase(BPELPlanContext context, String nodeInstanceURLVarName,

--- a/org.opentosca.planbuilder.postphase.plugin.instancedata/src/org/opentosca/planbuilder/postphase/plugin/instancedata/bpel/Handler.java
+++ b/org.opentosca.planbuilder.postphase.plugin.instancedata/src/org/opentosca/planbuilder/postphase/plugin/instancedata/bpel/Handler.java
@@ -123,7 +123,7 @@ public class Handler {
 
 
 
-    public boolean handleTerminate(final BPELPlanContext context, final AbstractNodeTemplate nodeTemplate) {
+    public boolean handleTerminate(final BPELPlanContext context, final AbstractNodeTemplate nodeTemplate) {               
         final boolean hasProps = checkProperties(nodeTemplate.getProperties());
 
         final String serviceInstanceVarName = context.getServiceInstanceURLVarName();
@@ -342,7 +342,7 @@ public class Handler {
         }
 
         this.appendStateUpdateToPostPhase(context, nodeInstanceURLVarName, stateVarName, lastSetState);
-
+        this.appendFailedStateToCompensationHandler(context, nodeInstanceURLVarName);
         return true;
     }
 
@@ -526,7 +526,7 @@ public class Handler {
         }
 
         this.appendStateUpdateToPostPhase(context, relationInstanceURLVarName, stateVarName, lastSetState);
-
+        this.appendFailedStateToCompensationHandler(context, relationInstanceURLVarName);
         return true;
     }
 
@@ -599,6 +599,9 @@ public class Handler {
         this.appendStateUpdateToPostPhase(targetContext, targetNodeInstanceUrlVar, stateVar);
         /* set state of old instance to migrated */
         this.appendStateUpdateToPostPhase(sourceContext, sourceNodeInstanceURLVarName, stateVar, "MIGRATED");
+        
+        this.appendFailedStateToCompensationHandler(targetContext, targetNodeInstanceUrlVar);
+        this.appendFailedStateToCompensationHandler(sourceContext, sourceNodeInstanceURLVarName);
         return true;
     }
 
@@ -898,6 +901,8 @@ public class Handler {
         // add progression log message
         appendProgressionUpdateLogMessage(context, nodeTemplate.getId());
 
+        this.appendFailedStateToCompensationHandler(context, nodeInstanceURLVarName);
+        
         return true;
     }
 
@@ -924,6 +929,11 @@ public class Handler {
             e.printStackTrace();
         }
         
+    }
+    
+    private void appendFailedStateToCompensationHandler(BPELPlanContext context, String nodeInstanceURLVarName) {
+        String stateVarName = this.createStateVar(context, context.getTemplateId());
+        this.appendStateUpdateAsChild(context, nodeInstanceURLVarName, stateVarName, "FAILED", context.getProvisioningCompensationPhaseElement());                
     }
 
     private void appendStateUpdateToPrePhase(BPELPlanContext context, String nodeInstanceURLVarName,

--- a/org.opentosca.planbuilder.postphase.plugin.instancedata/src/org/opentosca/planbuilder/postphase/plugin/instancedata/bpel/Handler.java
+++ b/org.opentosca.planbuilder.postphase.plugin.instancedata/src/org/opentosca/planbuilder/postphase/plugin/instancedata/bpel/Handler.java
@@ -342,7 +342,7 @@ public class Handler {
         }
 
         this.appendStateUpdateToPostPhase(context, nodeInstanceURLVarName, stateVarName, lastSetState);
-        this.appendFailedStateToCompensationHandler(context, nodeInstanceURLVarName);
+        this.appendFailedStateToFaultHandler(context, nodeInstanceURLVarName);
         return true;
     }
 
@@ -526,7 +526,7 @@ public class Handler {
         }
 
         this.appendStateUpdateToPostPhase(context, relationInstanceURLVarName, stateVarName, lastSetState);
-        this.appendFailedStateToCompensationHandler(context, relationInstanceURLVarName);
+        this.appendFailedStateToFaultHandler(context, relationInstanceURLVarName);
         return true;
     }
 
@@ -600,8 +600,8 @@ public class Handler {
         /* set state of old instance to migrated */
         this.appendStateUpdateToPostPhase(sourceContext, sourceNodeInstanceURLVarName, stateVar, "MIGRATED");
         
-        this.appendFailedStateToCompensationHandler(targetContext, targetNodeInstanceUrlVar);
-        this.appendFailedStateToCompensationHandler(sourceContext, sourceNodeInstanceURLVarName);
+        this.appendFailedStateToFaultHandler(targetContext, targetNodeInstanceUrlVar);
+        this.appendFailedStateToFaultHandler(sourceContext, sourceNodeInstanceURLVarName);
         return true;
     }
 
@@ -901,7 +901,7 @@ public class Handler {
         // add progression log message
         appendProgressionUpdateLogMessage(context, nodeTemplate.getId());
 
-        this.appendFailedStateToCompensationHandler(context, nodeInstanceURLVarName);
+        this.appendFailedStateToFaultHandler(context, nodeInstanceURLVarName);
         
         return true;
     }
@@ -931,9 +931,9 @@ public class Handler {
         
     }
     
-    private void appendFailedStateToCompensationHandler(BPELPlanContext context, String nodeInstanceURLVarName) {
+    private void appendFailedStateToFaultHandler(BPELPlanContext context, String nodeInstanceURLVarName) {
         String stateVarName = this.createStateVar(context, context.getTemplateId());
-        this.appendStateUpdateAsChild(context, nodeInstanceURLVarName, stateVarName, "FAILED", context.getProvisioningFaultHandlerPhaseElement());                
+        this.appendStateUpdateAsChild(context, nodeInstanceURLVarName, stateVarName, "ERROR", context.getProvisioningFaultHandlerPhaseElement());                
     }
 
     private void appendStateUpdateToPrePhase(BPELPlanContext context, String nodeInstanceURLVarName,


### PR DESCRIPTION
If some errors occur the plans currently call the compensation handlers by adding setting the state to failed within those handlers the instance data can reflect the failing of nodes
 
Signed-off-by: Kálmán Képes <kalman.kepes@iaas.uni-stuttgart.de>