### PR TITLE
fixes issue that caused the planbuilder service not to be available anymore in the API

### DIFF
--- a/org.opentosca.container.api/src/org/opentosca/container/api/controller/RootController.java
+++ b/org.opentosca.container.api/src/org/opentosca/container/api/controller/RootController.java
@@ -23,6 +23,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.opentosca.container.api.dto.ResourceSupport;
+import org.opentosca.planbuilder.service.resources.RootResource;
 
 import io.swagger.annotations.Contact;
 import io.swagger.annotations.Info;
@@ -51,10 +52,9 @@ public class RootController {
         links.add(Link.fromResource(CsarController.class).rel("csars").baseUri(this.uriInfo.getBaseUri()).build());
         links.add(Link.fromResource(SituationsController.class).rel("situationsapi").baseUri(this.uriInfo.getBaseUri())
                       .build());
+        // somehow using the style of creating the link like the above creates duplicate paths, e.g., host:1337/planbuilder/planbuilder        
+        links.add(Link.fromUriBuilder(this.uriInfo.getBaseUriBuilder().path(RootResource.class).path("planbuilder")).rel("planbuilder").build());
 
-        // Link to plan builder resources
-        links.add(Link.fromUriBuilder(this.uriInfo.getBaseUriBuilder().path("containerapi").path("planbuilder"))
-                      .rel("planbuilder").baseUri(this.uriInfo.getBaseUri()).build());
 
         return Response.ok(links).build();
     }

--- a/org.opentosca.planbuilder.service/META-INF/MANIFEST.MF
+++ b/org.opentosca.planbuilder.service/META-INF/MANIFEST.MF
@@ -4,7 +4,8 @@ Bundle-Name: PlanBuilder REST Service
 Bundle-SymbolicName: org.opentosca.planbuilder.service
 Bundle-Version: 2.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: javax.servlet;version="2.5.0",
+Import-Package: io.swagger.annotations;version="1.5.7.SNAPSHOT",
+ javax.servlet;version="2.5.0",
  javax.ws.rs;version="1.1.1",
  javax.ws.rs.core;version="1.1.1",
  org.apache.commons.io;version="2.2.0",

--- a/org.opentosca.planbuilder.service/src/org/opentosca/planbuilder/service/resources/RootResource.java
+++ b/org.opentosca.planbuilder.service/src/org/opentosca/planbuilder/service/resources/RootResource.java
@@ -32,7 +32,7 @@ import org.opentosca.planbuilder.service.model.PlanGenerationState;
  * @author Kalman Kepes - kepeskn@studi.informatik.uni-stuttgart.de
  *
  */
-@Path("planbuilder")
+@Path("/")
 public class RootResource {
 
     @Context
@@ -40,7 +40,7 @@ public class RootResource {
 
 
     @GET
-    @Produces("text/html")
+    @Produces("text/html")    
     public Response getRootPage() {
         return Response.ok("<html><body><h1>Hello to the PlanBuilder Service.</h1> <h2>To use the PlanBuilder Service send a POST Request with the following example body:</h2><textarea style=\"width:auto;height:auto;min-width:300px;min-height:200px\"> <generatePlanForTopology><CSARURL>http://<url-to-csar-file></CSARURL><PLANPOSTURL>http://<url-for-sending-plan-back-with-POST></PLANPOSTURL></generatePlanForTopology></textarea></body></html>")
                        .build();


### PR DESCRIPTION
The planbuilder enables to create plans for a given CSAR via a simple API call. It creates a new CSAR with the plans. Feature is used in eclipse winery to pregenerate plans
