### PR TITLE
removes comments out of xml files that are used as bpel fragments

### DIFF
--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightDELETE.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightDELETE.xml
@@ -1,6 +1,4 @@
 <bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $urlVarName, $ResponseVarName  -->
-    <!--  response="$ResponseVarName" -->
 	<bpel4RestLight:DELETE
 		uri="$bpelvar[$urlVarName]"
 		accept="application/xml"></bpel4RestLight:DELETE>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightGET_NodeInstance_InstanceDataAPI.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightGET_NodeInstance_InstanceDataAPI.xml
@@ -1,5 +1,4 @@
 <bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $InstanceDataURLVar, $ResponseVarName, $templateId  -->
 	<bpel4RestLight:GET
 		uri="$bpelvar[$InstanceDataURLVar]/nodetemplates/$templateId/instances?query"
 		accept="application/xml" response="$ResponseVarName"></bpel4RestLight:GET>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightGET_NodeInstance_Properties.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightGET_NodeInstance_Properties.xml
@@ -1,5 +1,4 @@
 <bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $urlVarName, $ResponseVarName  -->
 	<bpel4RestLight:GET
 		uri="$bpelvar[$urlVarName]/properties"
 		accept="application/xml" response="$ResponseVarName"></bpel4RestLight:GET>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightGET_NodeInstances_InstanceDataAPI.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightGET_NodeInstances_InstanceDataAPI.xml
@@ -1,5 +1,4 @@
 <bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $serviceInstanceURLVar, $nodeTemplateId, $ResponseVarName  -->
 	<bpel4RestLight:GET
 		uri="$bpelvar[$serviceInstanceURLVar]/NodeTemplates/$nodeTemplateId/Instances"
 		accept="application/xml" response="$ResponseVarName"></bpel4RestLight:GET>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightGET_RelationInstance_InstanceDataAPI.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightGET_RelationInstance_InstanceDataAPI.xml
@@ -1,5 +1,4 @@
 <bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $InstanceDataURLVar, $ResponseVarName, $templateId  -->
 	<bpel4RestLight:GET
 		uri="$bpelvar[$InstanceDataURLVar]/relationshiptemplates/$templateId/instances?query"
 		accept="application/xml" response="$ResponseVarName"></bpel4RestLight:GET>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightGET_RelationInstances_InstanceDataAPI.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightGET_RelationInstances_InstanceDataAPI.xml
@@ -1,5 +1,4 @@
 <bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $serviceInstanceURLVar, $relationshipTemplateId, $ResponseVarName -->
 	<bpel4RestLight:GET
 		uri="$bpelvar[$serviceInstanceURLVar]/RelationshipTemplates/$relationshipTemplateId/Instances"
 		accept="application/xml" response="$ResponseVarName"></bpel4RestLight:GET>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightGET_RelationInstances_QueryOnTargetInstance_InstanceDataAPI.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightGET_RelationInstances_QueryOnTargetInstance_InstanceDataAPI.xml
@@ -1,6 +1,4 @@
 <bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $serviceInstanceURLVar, $relationshipTemplateId, $ResponseVarName, $nodeInstanceIdVarName  -->
-    <!-- $ServiceTemplateURLVarKeyword, $relationshipTemplateId, $nodeInstanceIdVarName, $ResponseVarName-->
 	<bpel4RestLight:GET
 		uri="$bpelvar[$ServiceTemplateURLVarKeyword]/relationshiptemplates/$relationshipTemplateId/instances?target=$bpelvar[$nodeInstanceIdVarName]"
 		accept="application/xml" response="$ResponseVarName"></bpel4RestLight:GET>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightGET_URL_ApplicationXML.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightGET_URL_ApplicationXML.xml
@@ -1,5 +1,4 @@
 <bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $ResponseVarName, $urlVar  -->
 	<bpel4RestLight:GET
 		uri="$bpelvar[$urlVar]"
 		accept="application/xml" response="$ResponseVarName"></bpel4RestLight:GET>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightPOST_PlanInstance_Logs.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightPOST_PlanInstance_Logs.xml
@@ -19,7 +19,6 @@
 		</bpel:assign>
 		<bpel:extensionActivity
 			xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-			<!-- $urlVarName, $requestVar, $correlationId -->
 			<bpel4RestLight:POST uri="$bpelvar[$urlVarName]/logs"
 				request="$requestVar"></bpel4RestLight:POST>
 		</bpel:extensionActivity>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightPOST_ServiceInstance_InstanceDataAPI.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightPOST_ServiceInstance_InstanceDataAPI.xml
@@ -1,5 +1,4 @@
 <bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $InstanceDataURLVar, $CSARName, $serviceTemplateId, $ResponseVarName  -->
 	<bpel4RestLight:POST
 		uri="$bpelvar[$InstanceDataURLVar]"
 		accept="application/xml" response="$ResponseVarName"></bpel4RestLight:POST>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightPOST_ServiceInstance_InstanceDataAPI_WithBody.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightPOST_ServiceInstance_InstanceDataAPI_WithBody.xml
@@ -1,5 +1,4 @@
 <bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $InstanceDataURLVar, $ResponseVarName, $RequestVarName  -->
 	<bpel4RestLight:POST
 		uri="$bpelvar[$InstanceDataURLVar]"
 		accept="application/xml" contenttype="application/xml" request="$RequestVarName" response="$ResponseVarName"></bpel4RestLight:POST>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightPUTInstanceState.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPEL4RESTLightPUTInstanceState.xml
@@ -1,5 +1,4 @@
 <bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $urlVarName, $requestVar  -->
 	<bpel4RestLight:PUT
 		uri="$bpelvar[$urlVarName]/state"
 		accept="application/xml" contenttype="text/plain" request="$requestVar"></bpel4RestLight:PUT>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPELCompareInstanceCounts.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPELCompareInstanceCounts.xml
@@ -32,7 +32,6 @@
 		<bpel:sequence>
 			<!-- assign last nodeInstance from list -->
 			<bpel:assign validate="no" name="{AssignName}">
-				<!-- {AssignName},{xpath2query}, {stringVarName} -->
 				<bpel:copy>
 					<bpel:from expressionLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0">
 			<![CDATA[{xpath2query}]]>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPELIfTrueThrowFault.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPELIfTrueThrowFault.xml
@@ -1,5 +1,4 @@
 <bpel:if xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-<!--  $xpath1Expr, $faultPrefix, $faultNamespace, $faultLocalName-->
 	<bpel:condition expressionLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath1.0">
 		$xpath1Expr
 	</bpel:condition>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPELMonitoringSituation.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BPELMonitoringSituation.xml
@@ -26,7 +26,6 @@
   </bpel:assign>
   <bpel:extensionActivity
     xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $urlVarName, $requestVar, $correlationId -->
     <bpel4RestLight:POST uri="$bpelvar[$urlVarName]/situationsmonitors"
       request="$requestVar" contenttype="application/xml" accept="application/xml"></bpel4RestLight:POST>
   </bpel:extensionActivity>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelAssignFromInputToStringVar.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelAssignFromInputToStringVar.xml
@@ -1,6 +1,5 @@
 <bpel:assign xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" validate="no" name="$assignName">
     <bpel:copy>
-        <!-- $inputElementLocalName, $StringVariableName, $assignName -->
         <bpel:from part="payload" variable="input"><bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath1.0"><![CDATA[//*[local-name()='$inputElementLocalName']/text()]]></bpel:query></bpel:from>
         <bpel:to variable="$StringVariableName"></bpel:to>
     </bpel:copy>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelAssignFromNodeInstanceRequestToStringVar.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelAssignFromNodeInstanceRequestToStringVar.xml
@@ -1,6 +1,5 @@
 <bpel:assign xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" validate="no" name="$assignName">
     <bpel:copy>
-        <!-- $assignName, $stringVarName, $NodeInstanceResponseVarName -->
         <bpel:from variable="$NodeInstanceResponseVarName"><bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0" xmlns:pp="http://opentosca.org/api/pp" xmlns:xlink="http://www.w3.org/1999/xlink"><![CDATA[string(//pp:NodeInstanceList/pp:nodeinstances/pp:link/@xlink:href)]]></bpel:query></bpel:from>
         <bpel:to variable="$stringVarName"></bpel:to>
     </bpel:copy>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelAssignSelectFromNodeInstancesRequestToStringVar.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelAssignSelectFromNodeInstancesRequestToStringVar.xml
@@ -1,6 +1,5 @@
 <bpel:assign xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" validate="no" name="$assignName">
     <bpel:copy>
-        <!-- $assignName, $stringVarName, $NodeInstancesResponseVarName -->
         <bpel:from variable="$NodeInstancesResponseVarName"><bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0"><![CDATA[//*[local-name()='NodeTemplateInstanceResources']/*[local-name()='NodeTemplateInstances']/*[local-name()='NodeTemplateInstance'][1]/*[local-name()='Links']/*[local-name()='Link']/@*[local-name()='href']/string()]]></bpel:query></bpel:from>
         <bpel:to variable="$stringVarName"></bpel:to>
     </bpel:copy>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelAssignSelectFromRelationInstancesRequestToStringVar.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelAssignSelectFromRelationInstancesRequestToStringVar.xml
@@ -1,6 +1,5 @@
 <bpel:assign xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" validate="no" name="$assignName">
     <bpel:copy>
-        <!-- $assignName, $stringVarName, $NodeInstancesResponseVarName -->
         <bpel:from variable="$NodeInstancesResponseVarName"><bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0"><![CDATA[//*[local-name()='RelationshipTemplateInstanceResources']/*[local-name()='RelationshipTemplateInstances']/*[local-name()='RelationshipTemplateInstance'][1]/*[local-name()='Links']/*[local-name()='Link']/@*[local-name()='href']/string()]]></bpel:query></bpel:from>
         <bpel:to variable="$stringVarName"></bpel:to>
     </bpel:copy>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelAssignServiceInstanceCorrelationIdPOSTRequest.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelAssignServiceInstanceCorrelationIdPOSTRequest.xml
@@ -1,7 +1,5 @@
 <bpel:assign xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable"
 	validate="yes" name="$assignName">
-	<!--$assignName : Reads from $inputElementLocalName and adds the content
-		inside $StringVariableName wrapped inside a CorrelationId element -->
 	<bpel:copy>
 		<bpel:from>
 			<bpel:literal><correlationID xmlns="http://opentosca.org/api">notSet</correlationID></bpel:literal>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelAssignServiceInstanceIDFromServiceInstanceUrl.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelAssignServiceInstanceIDFromServiceInstanceUrl.xml
@@ -1,9 +1,6 @@
 <bpel:assign xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable"
 	validate="no" name="$assignName">
-	<!-- $ServiceInstanceURLVarName, $ServiceInstanceIDVarName -->
 	<bpel:copy>
-		<!-- //*[local-name()='link' and namespace-uri()='http://opentosca.org/api/pp']/@*[local-name()='href'
-			and namespace-uri()='http://www.w3.org/1999/xlink'] -->
 		<bpel:from variable="$ServiceInstanceURLVarName">
 			<bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0"><![CDATA[string(codepoints-to-string(reverse(string-to-codepoints(substring-before(codepoints-to-string(reverse(string-to-codepoints($$ServiceInstanceURLVarName))), '/')))))]]></bpel:query>
 		</bpel:from>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelAssignServiceInstancePOSTResponse.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelAssignServiceInstancePOSTResponse.xml
@@ -1,9 +1,6 @@
 <bpel:assign xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable"
-	validate="no" name="$assignName">
-	<!-- $ServiceInstanceResponseVarName, $ServiceInstanceURLVarName, $serviceTemplateURLVarName, $serviceTemplateInstancesURLVar, $ServiceInstanceIDVarName -->
+	validate="no" name="$assignName">	
 	<bpel:copy>
-		<!-- //*[local-name()='link' and namespace-uri()='http://opentosca.org/api/pp']/@*[local-name()='href'
-			and namespace-uri()='http://www.w3.org/1999/xlink'] -->
 		<bpel:from variable="$ServiceInstanceResponseVarName">
 			<bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0"
 				xmlns:pp="http://opentosca.org/api/pp" xmlns:xlink="http://www.w3.org/1999/xlink"><![CDATA[string(//*[local-name()='url']/text())]]></bpel:query>
@@ -11,16 +8,12 @@
 		<bpel:to variable="$ServiceInstanceURLVarName"></bpel:to>
 	</bpel:copy>
 	<bpel:copy>
-		<!-- //*[local-name()='link' and namespace-uri()='http://opentosca.org/api/pp']/@*[local-name()='href'
-			and namespace-uri()='http://www.w3.org/1999/xlink'] -->
 		<bpel:from variable="$ServiceInstanceURLVarName">
 			<bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0"><![CDATA[string(codepoints-to-string(reverse(string-to-codepoints(substring-before(codepoints-to-string(reverse(string-to-codepoints($$ServiceInstanceURLVarName))), '/')))))]]></bpel:query>
 		</bpel:from>
 		<bpel:to variable="$ServiceInstanceIDVarName"></bpel:to>
 	</bpel:copy>
 	<bpel:copy>
-		<!-- //*[local-name()='link' and namespace-uri()='http://opentosca.org/api/pp']/@*[local-name()='href'
-			and namespace-uri()='http://www.w3.org/1999/xlink'] -->
 		<bpel:from variable="$serviceTemplateInstancesURLVar">
 			<bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0"><![CDATA[string(replace($$serviceTemplateInstancesURLVar, '/instances', ''))]]></bpel:query>
 		</bpel:from>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelAssignServiceInstancePOSTResponse2.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelAssignServiceInstancePOSTResponse2.xml
@@ -1,9 +1,6 @@
 <bpel:assign xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable"
 	validate="no" name="$assignName">
-	<!-- $ServiceInstanceResponseVarName, $ServiceInstanceURLVarName, $serviceTemplateURLVarName, $serviceTemplateInstancesURLVar, $ServiceInstanceIDVarName -->
 	<bpel:copy>
-		<!-- //*[local-name()='link' and namespace-uri()='http://opentosca.org/api/pp']/@*[local-name()='href'
-			and namespace-uri()='http://www.w3.org/1999/xlink'] -->
 		<bpel:from variable="$ServiceInstanceResponseVarName">
 			<bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0"
 				xmlns:pp="http://opentosca.org/api/pp" xmlns:xlink="http://www.w3.org/1999/xlink"><![CDATA[string(//*[local-name()='url']/text())]]></bpel:query>
@@ -11,16 +8,12 @@
 		<bpel:to variable="$ServiceInstanceURLVarName"></bpel:to>
 	</bpel:copy>
 	<bpel:copy>
-		<!-- //*[local-name()='link' and namespace-uri()='http://opentosca.org/api/pp']/@*[local-name()='href'
-			and namespace-uri()='http://www.w3.org/1999/xlink'] -->
 		<bpel:from variable="$ServiceInstanceURLVarName">
 			<bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0"><![CDATA[string(codepoints-to-string(reverse(string-to-codepoints(substring-before(codepoints-to-string(reverse(string-to-codepoints($$ServiceInstanceURLVarName))), '/')))))]]></bpel:query>
 		</bpel:from>
 		<bpel:to variable="$ServiceInstanceIDVarName"></bpel:to>
 	</bpel:copy>
 	<bpel:copy>
-		<!-- //*[local-name()='link' and namespace-uri()='http://opentosca.org/api/pp']/@*[local-name()='href'
-			and namespace-uri()='http://www.w3.org/1999/xlink'] -->
 		<bpel:from variable="$serviceTemplateInstancesURLVar">
 			<bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0"><![CDATA[string(replace($$serviceTemplateInstancesURLVar, '/instances', ''))]]></bpel:query>
 		</bpel:from>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelCopyFromPropertyVarToNodeInstanceProperty.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelCopyFromPropertyVarToNodeInstanceProperty.xml
@@ -1,5 +1,4 @@
 <bpel:copy xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable">
-	<!-- $PropertyVarName, $NodeInstancePropertyRequestVarName, $NodeInstancePropertyLocalName, $NodeInstancePropertyNamespace -->
 	<bpel:from variable="$NodeInstancePropertyRequestVarName">
 	    <bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath1.0"><![CDATA[//*[local-name()='$NodeInstancePropertyLocalName' and namespace-uri()='$NodeInstancePropertyNamespace']]]></bpel:query>
 	</bpel:from>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelCopyOutputVarFromStringVariable.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/BpelCopyOutputVarFromStringVariable.xml
@@ -1,5 +1,4 @@
 <bpel:copy xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable">
-<!-- ${variableName}, ${outputVarName}, ${outputVarPartName}, ${outputVarLocalName} -->
   <bpel:from variable="${variableName}"></bpel:from>
   <bpel:to variable="${outputVarName}" part="${outputVarPartName}">
     <bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath1.0"><![CDATA[//*[local-name()='${outputVarLocalName}']]]></bpel:query>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/assignStringVarWithXpath2Query.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/assignStringVarWithXpath2Query.xml
@@ -1,7 +1,5 @@
 <bpel:assign validate="no" name="{AssignName}"
 	xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable">
-	<!-- {AssignName},{xpath2query}, {stringVarName} -->
-		    <!-- queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0" variable="{stringVarName}" -->
 	<bpel:copy>
 		<bpel:from expressionLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0">
 			<![CDATA[{xpath2query}]]>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/assignVarFromVarWithXpath2Queries.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/assignVarFromVarWithXpath2Queries.xml
@@ -1,6 +1,5 @@
 <bpel:assign validate="no" name="$assignName"
 	xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable">
-	<!-- $xpath2query1,$xpath2query2, $fromVarName, $toVarName, $intent -->
 	<bpel:copy $extension>
 		<bpel:from variable="$fromVarName" $part1>
 			<bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0"><![CDATA[$xpath2query1]]></bpel:query>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/assignVarFromVarWithXpath2Query.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/assignVarFromVarWithXpath2Query.xml
@@ -1,6 +1,5 @@
 <bpel:assign validate="no" name="$assignName"
-	xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable">
-	<!-- $xpath2query, $fromVarName, $toVarName -->		    
+	xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable">		    
 	<bpel:copy>
 		<bpel:from variable="$fromVarName">
 			<bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0"><![CDATA[$xpath2query]]></bpel:query>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/assignVarWithLiteral.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/resources/core-bpel/assignVarWithLiteral.xml
@@ -1,9 +1,4 @@
 <bpel:assign xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" validate="no" name="AssignVarWihtLiteral">
-<!-- Assign Variable with literal:
-	Literal = $literal
-	VarName = $VarName
-	Intent = $intent
- -->
 	<bpel:copy>
 		<bpel:from>
 			<bpel:literal>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightDELETE.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightDELETE.xml
@@ -1,6 +1,4 @@
-<bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $urlVarName, $ResponseVarName  -->
-    <!--  response="$ResponseVarName" -->
+<bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">    
 	<bpel4RestLight:DELETE
 		uri="$bpelvar[$urlVarName]"
 		accept="application/xml"></bpel4RestLight:DELETE>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightGET.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightGET.xml
@@ -1,5 +1,4 @@
 <bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $urlVarName, $ResponseVarName  -->
 	<bpel4RestLight:GET
 		uri="$bpelvar[$urlVarName]"
 		accept="application/xml" response="$ResponseVarName"></bpel4RestLight:GET>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightGET_Instance_Properties.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightGET_Instance_Properties.xml
@@ -1,5 +1,4 @@
 <bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $urlVarName, $ResponseVarName  -->
 	<bpel4RestLight:GET
 		uri="$bpelvar[$urlVarName]/properties"
 		accept="application/xml" response="$ResponseVarName"></bpel4RestLight:GET>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightGET_Instance_State_InstanceDataAPI.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightGET_Instance_State_InstanceDataAPI.xml
@@ -1,5 +1,4 @@
-<bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $RequestVarName,$ResponseVarName, $instanceURLVar  -->
+<bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">    
 	<bpel4RestLight:GET
 		uri="$bpelvar[$instanceURLVar]/state"
 		accept="text/plain" response="$ResponseVarName"></bpel4RestLight:GET>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightGET_NodeInstance_InstanceDataAPI.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightGET_NodeInstance_InstanceDataAPI.xml
@@ -1,5 +1,4 @@
 <bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $InstanceDataURLVar, $ResponseVarName, $nodeType -->
 	<bpel4RestLight:GET
 		uri="$bpelvar[$InstanceDataURLVar]/NodeTemplates?nodeType=$nodeType"
 		accept="application/xml" response="$ResponseVarName"></bpel4RestLight:GET>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightPOST_NodeInstance_InstanceDataAPI.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightPOST_NodeInstance_InstanceDataAPI.xml
@@ -1,5 +1,4 @@
 <bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $serviceInstanceURLVar, $serviceInstanceIDVar, $nodeTemplateId, $ResponseVarName  -->
 	<bpel4RestLight:POST
 		uri="$bpelvar[$serviceInstanceURLVar]/nodetemplates/$nodeTemplateId/instances"
 		accept="application/xml" contenttype="text/plain" request="$serviceInstanceIDVar" response="$ResponseVarName"></bpel4RestLight:POST>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightPOST_RelationInstance_InstanceDataAPI.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightPOST_RelationInstance_InstanceDataAPI.xml
@@ -39,8 +39,6 @@
 		<bpel:extensionActivity
 			xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable"
 			xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-			<!-- $serviceInstanceURLVar, $relationshipTemplateId, $ResponseVarName,
-				$sourceInstanceIdVarName, $targetInstanceIdVarName -->
 			<bpel4RestLight:POST
 				uri="$bpelvar[$serviceInstanceURLVar]/relationshiptemplates/$relationshipTemplateId/instances"
 				accept="application/xml" contenttype="application/xml" request="$RequestVarName"

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightPOST_ServiceInstance_InstanceDataAPI.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightPOST_ServiceInstance_InstanceDataAPI.xml
@@ -1,5 +1,4 @@
-<bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $InstanceDataURLVar, $CSARName, $serviceTemplateId, $ResponseVarName  -->
+<bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">    
 	<bpel4RestLight:POST
 		uri="$bpelvar[$InstanceDataURLVar]/serviceInstances?csarID=$CSARName&amp;serviceTemplateID=$serviceTemplateId"
 		accept="application/xml" response="$ResponseVarName"></bpel4RestLight:POST>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightPUT_Instance_InstanceDataAPI.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightPUT_Instance_InstanceDataAPI.xml
@@ -1,5 +1,4 @@
 <bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $RequestVarName,$instanceURLVar  -->
 	<bpel4RestLight:PUT
 		uri="$bpelvar[$instanceURLVar]/properties"
 		accept="application/xml" request="$RequestVarName"></bpel4RestLight:PUT>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightPUT_Instance_State_InstanceDataAPI.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPEL4RESTLightPUT_Instance_State_InstanceDataAPI.xml
@@ -1,5 +1,4 @@
 <bpel:extensionActivity xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-    <!-- $RequestVarName,$instanceURLVar  -->
 	<bpel4RestLight:PUT
 		uri="$bpelvar[$instanceURLVar]/state"
 		accept="text/plain" contenttype="text/plain" request="$RequestVarName"></bpel4RestLight:PUT>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPELAssignFromNodeInstancePOSTResponseToStringVar.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPELAssignFromNodeInstancePOSTResponseToStringVar.xml
@@ -1,7 +1,6 @@
 <bpel:assign xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable"
 	validate="no" name="$assignName">
 	<bpel:copy>
-		<!-- $stringVarName, $NodeInstanceResponseVarName -->
 		<bpel:from variable="$NodeInstanceResponseVarName">
 			<bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0"><![CDATA[string(//*[local-name()='url']/text())]]></bpel:query>
 		</bpel:from>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPELAssignFromRelationInstancePOSTResponseToStringVar.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BPELAssignFromRelationInstancePOSTResponseToStringVar.xml
@@ -1,6 +1,5 @@
 <bpel:assign xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" validate="no" name="$assignName">
-    <bpel:copy>
-		<!-- $stringVarName, $RelationInstanceResponseVarName, relationInstanceIDVar-->
+    <bpel:copy>		
 		<bpel:from variable="$RelationInstanceResponseVarName">
 			<bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0"><![CDATA[string(//*[local-name()='url']/text())]]></bpel:query>
 		</bpel:from>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BpelAssignFromInputToStringVar.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BpelAssignFromInputToStringVar.xml
@@ -1,6 +1,5 @@
 <bpel:assign xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" validate="no" name="$assignName">
     <bpel:copy>
-        <!-- $inputElementLocalName, $StringVariableName, $assignName -->
         <bpel:from part="payload" variable="input"><bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath1.0"><![CDATA[//*[local-name()='$inputElementLocalName']/text()]]></bpel:query></bpel:from>
         <bpel:to variable="$StringVariableName"></bpel:to>
     </bpel:copy>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BpelAssignFromNodeInstanceRequestToStringVar.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BpelAssignFromNodeInstanceRequestToStringVar.xml
@@ -1,6 +1,5 @@
 <bpel:assign xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" validate="no" name="$assignName">
-    <bpel:copy>
-        <!-- $stringVarName, $NodeInstanceResponseVarName -->
+    <bpel:copy>        
         <bpel:from variable="$NodeInstanceResponseVarName"><bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0" xmlns:pp="http://opentosca.org/api/pp" xmlns:xlink="http://www.w3.org/1999/xlink"><![CDATA[string(//*[local-name()='References']/*[local-name()='Reference' and @xlink:type='Reference']/@xlink:href)]]></bpel:query></bpel:from>
         <bpel:to variable="$stringVarName"></bpel:to>
     </bpel:copy>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BpelAssignFromServiceInstanceRequestToStringVar.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BpelAssignFromServiceInstanceRequestToStringVar.xml
@@ -1,6 +1,5 @@
 <bpel:assign xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" validate="no" name="$assignName">
     <bpel:copy>
-        <!-- $stringVarName, $ServiceInstanceResponseVarName, $nodeInstanceIndex -->
         <bpel:from variable="$ServiceInstanceResponseVarName"><bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0" xmlns:pp="http://opentosca.org/api/pp" xmlns:xlink="http://www.w3.org/1999/xlink"><![CDATA[string(//pp:ServiceInstance/pp:nodeInstances/pp:nodeInstance)[$nodeInstanceIndex]/@xlink:href)]]></bpel:query></bpel:from>
         <bpel:to variable="$stringVarName"></bpel:to>
     </bpel:copy>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BpelAssignServiceInstancePOSTResponse.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BpelAssignServiceInstancePOSTResponse.xml
@@ -1,6 +1,5 @@
 <bpel:assign xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" validate="no" name="$assignName">
     <bpel:copy>
-        <!-- //*[local-name()='link' and namespace-uri()='http://opentosca.org/api/pp']/@*[local-name()='href' and namespace-uri()='http://www.w3.org/1999/xlink'] -->
         <bpel:from variable="$ServiceInstanceResponseVarName"><bpel:query queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0" xmlns:pp="http://opentosca.org/api/pp" xmlns:xlink="http://www.w3.org/1999/xlink"><![CDATA[string(//pp:link/@xlink:href)]]></bpel:query></bpel:from>
         <bpel:to variable="$ServiceInstanceURLVarName"></bpel:to>
     </bpel:copy>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BpelCopyFromPropertyVarToNodeInstanceProperty.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.postphase.plugin.instancedata/src/main/resources/instancedata-plugin/BpelCopyFromPropertyVarToNodeInstanceProperty.xml
@@ -1,5 +1,4 @@
 <bpel:copy xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable">
-	<!-- $PropertyVarName, $NodeInstancePropertyRequestVarName, $NodeInstancePropertyLocalName, $NodeInstancePropertyNamespace -->
 	<bpel:from variable="$PropertyVarName">
 	</bpel:from>
 	<bpel:to variable="$NodeInstancePropertyRequestVarName">

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.provphase.plugin.invoker/src/main/resources/invoker-plugin/EPRCopyToInvokerReplyTo.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.provphase.plugin.invoker/src/main/resources/invoker-plugin/EPRCopyToInvokerReplyTo.xml
@@ -1,4 +1,3 @@
-<!--{partnerLinkName} {requestVarName}  {requestVarPartName} {invokerParamName}-->
 <bpel:copy>
 	<bpel:from partnerLink="{partnerLinkName}" endpointReference="myRole"></bpel:from>
 	<bpel:to variable="{requestVarName}" part="{requestVarPartName}">

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.provphase.plugin.invoker/src/main/resources/invoker-plugin/assignStringVarWithXpath2Query.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.provphase.plugin.invoker/src/main/resources/invoker-plugin/assignStringVarWithXpath2Query.xml
@@ -1,7 +1,5 @@
 <bpel:assign validate="no" name="{AssignName}"
 	xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable">
-	<!-- {AssignName},{xpath2query}, {stringVarName} -->
-		    <!-- queryLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0" variable="{stringVarName}" -->
 	<bpel:copy>
 		<bpel:from expressionLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0">
 			<![CDATA[{xpath2query}]]>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.provphase.plugin.invoker/src/main/resources/invoker-plugin/ifFaultMessageThrowFault.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.provphase.plugin.invoker/src/main/resources/invoker-plugin/ifFaultMessageThrowFault.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpel:if xmlns:bpel="http://docs.oasis-open.org/wsbpel/2.0/process/executable" xmlns:bpel4RestLight="http://www.apache.org/ode/bpel/extensions/bpel4restlight">
-<!--  $xpath1Expr, $faultPrefix, $faultNamespace, $faultLocalName-->
 	<bpel:condition expressionLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0"> 
 		<![CDATA[$xpath1Expr]]>
 	</bpel:condition>

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.provphase.plugin.invoker/src/main/resources/invoker-plugin/initMessageId.xml
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.provphase.plugin.invoker/src/main/resources/invoker-plugin/initMessageId.xml
@@ -1,5 +1,4 @@
 <bpel:copy>
-	<!-- {requestVarName}, {requestVarPartName}, {messageIdPrefix} -->
 	<bpel:from expressionLanguage="urn:oasis:names:tc:wsbpel:2.0:sublang:xpath2.0">
 		<![CDATA[concat('{messageIdPrefix}',current-dateTime())]]>
 	</bpel:from>


### PR DESCRIPTION
#### Short Description
some id can contain '--' which are not allowed in xml comments (<!-- -->), these were used within bpel fragments and often led to issue when generating plans


#### Proposed Changes

  * remove unnecessary comments

