### PR TITLE
Fix/multiplefixes

### DIFF
--- a/org.opentosca.container.api/src/main/java/org/opentosca/container/api/controller/ManagementPlanController.java
+++ b/org.opentosca.container.api/src/main/java/org/opentosca/container/api/controller/ManagementPlanController.java
@@ -113,7 +113,7 @@ public class ManagementPlanController {
 
         final PlanInstanceListDTO list = new PlanInstanceListDTO();
         planInstances.stream()
-            .filter(planInstance -> planInstance.getTemplateId().getLocalPart().equals(plan))
+            .filter(planInstance -> planInstance.getTemplateId().getLocalPart().equals(plan) && (planInstance.getServiceTemplateInstance().getId() == this.serviceTemplateInstanceId))
             .map(pi -> {
                 PlanInstanceDTO dto = PlanInstanceDTO.Converter.convert(pi);
                 if (pi.getServiceTemplateInstance() != null) {

--- a/org.opentosca.container.engine.plan.plugin.bpel/src/main/java/org/opentosca/container/engine/plan/plugin/bpel/util/ODEEndpointUpdater.java
+++ b/org.opentosca.container.engine.plan.plugin.bpel/src/main/java/org/opentosca/container/engine/plan/plugin/bpel/util/ODEEndpointUpdater.java
@@ -558,7 +558,7 @@ public class ODEEndpointUpdater {
                 port.getBinding().getPortType().getQName().toString());
             final List<WSDLEndpoint> temp = endpointService.getWSDLEndpoints();
             for (final WSDLEndpoint endpoint : temp) {
-                if (endpoint.getPortType().equals(port.getBinding().getPortType().getQName())
+                if (endpoint.getPortType() != null && endpoint.getPortType().equals(port.getBinding().getPortType().getQName())
                     && endpoint.getManagingContainer().equals(Settings.OPENTOSCA_CONTAINER_HOSTNAME)) {
                     LOG.debug("Found endpoint: {}", endpoint.getURI().toString());
                     endpoints.add(endpoint);

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.integration/src/main/java/org/opentosca/planbuilder/importer/winery/context/impl/impl/PolicyTemplateImpl.java
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.integration/src/main/java/org/opentosca/planbuilder/importer/winery/context/impl/impl/PolicyTemplateImpl.java
@@ -47,7 +47,7 @@ public class PolicyTemplateImpl extends AbstractPolicyTemplate {
     @Override
     public AbstractProperties getProperties() {
         if (this.policyTemplate.getProperties() != null) {
-            return new PropertiesImpl(this.policyTemplate.getProperties().getAny());
+            return new PropertiesImpl(this.policyTemplate.getProperties().getInternalAny());
         } else {
             return null;
         }

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.selection.plugin.firstavailable/src/main/java/org/opentosca/planbuilder/selection/plugin/firstavailable/bpel/BPELFirstAvailablePlugin.java
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.selection.plugin.firstavailable/src/main/java/org/opentosca/planbuilder/selection/plugin/firstavailable/bpel/BPELFirstAvailablePlugin.java
@@ -50,7 +50,7 @@ public class BPELFirstAvailablePlugin extends FirstAvailablePlugin<BPELPlanConte
             Node getNodeInstances =
                 new BPELProcessFragments().createRESTExtensionGETForNodeInstanceDataAsNode(serviceTemplateUrlVar,
                     responseVarName,
-                    nodeTemplate.getId(), null);
+                    nodeTemplate.getId(), "?serviceInstanceId=$bpelvar[" + context.getServiceInstanceIDVarName() +"]");
             getNodeInstances = context.importNode(getNodeInstances);
             context.getPrePhaseElement().appendChild(getNodeInstances);
 


### PR DESCRIPTION
- fixes issue that showed managementplan instance under the wrong service instance
- fixes issue that throws a nullpointer when there are endpoints without a portType defined
- fixes issue with selecting the proper node instance by scale out plans using the "first available" selection plugin
- fixes empty properties of tosca properties of policy templates inside the planbuilder model