### PR TITLE
refactors some aspects of plan management

### DIFF
--- a/org.opentosca.bus/org.opentosca.bus.management.service/src/main/java/org/opentosca/bus/management/service/impl/ManagementBusServiceImpl.java
+++ b/org.opentosca.bus/org.opentosca.bus.management.service/src/main/java/org/opentosca/bus/management/service/impl/ManagementBusServiceImpl.java
@@ -955,12 +955,14 @@ public class ManagementBusServiceImpl implements IManagementBusService {
             endpointService.getWSDLEndpointsForPlanId(Settings.OPENTOSCA_CONTAINER_HOSTNAME, arguments.csar.id(),
                 plan.getTemplateId());
 
+
+
         // choose WSDL endpoint depending on the invokation of the invoker or callback port type
         WSDLEndpoint WSDLendpoint = null;
         if (Objects.isNull(callbackInvocation) || !callbackInvocation) {
             WSDLendpoint =
                 WSDLendpoints.stream()
-                    .filter(endpoint -> !endpoint.getPortType().equals(Constants.CALLBACK_PORT_TYPE))
+                    .filter(endpoint -> endpoint.getPortType() == null || !endpoint.getPortType().equals(Constants.CALLBACK_PORT_TYPE))
                     .findFirst().orElse(null);
         } else {
             LOG.debug("Invokation using callback.");

--- a/org.opentosca.container.api/src/main/java/org/opentosca/container/api/controller/PlanbuilderController.java
+++ b/org.opentosca.container.api/src/main/java/org/opentosca/container/api/controller/PlanbuilderController.java
@@ -41,7 +41,7 @@ import org.springframework.stereotype.Component;
  *
  * @author Kalman Kepes - kepeskn@studi.informatik.uni-stuttgart.de
  */
-@Path("containerapi/planbuilder")
+@Path("planbuilder")
 @Component
 @NonNullByDefault
 public class PlanbuilderController {

--- a/org.opentosca.container.api/src/main/java/org/opentosca/container/api/controller/PlanbuilderController.java
+++ b/org.opentosca.container.api/src/main/java/org/opentosca/container/api/controller/PlanbuilderController.java
@@ -41,7 +41,7 @@ import org.springframework.stereotype.Component;
  *
  * @author Kalman Kepes - kepeskn@studi.informatik.uni-stuttgart.de
  */
-@Path("planbuilder")
+@Path("containerapi/planbuilder")
 @Component
 @NonNullByDefault
 public class PlanbuilderController {
@@ -52,7 +52,9 @@ public class PlanbuilderController {
     @Context
     UriInfo uriInfo;
 
-    private final CsarStorageService csarStorage;
+    @Inject
+    private CsarStorageService csarStorage;
+
     private final Importer importer;
     private final IHTTPService httpService;
 
@@ -60,7 +62,7 @@ public class PlanbuilderController {
     public PlanbuilderController(Importer importer, IHTTPService httpService) {
         this.httpService = httpService;
         this.importer = importer;
-        csarStorage = new CsarStorageServiceImpl(Settings.CONTAINER_STORAGE_BASEPATH.resolveSibling("planbuilder-application"));
+        //csarStorage = new CsarStorageServiceImpl(Settings.CONTAINER_STORAGE_BASEPATH.resolveSibling("planbuilder-application"));
     }
 
     @GET

--- a/org.opentosca.container.api/src/main/java/org/opentosca/container/api/controller/RootController.java
+++ b/org.opentosca.container.api/src/main/java/org/opentosca/container/api/controller/RootController.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.opentosca.container.api.controller;
 
-import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -28,7 +27,6 @@ import io.swagger.annotations.Info;
 import io.swagger.annotations.License;
 import io.swagger.annotations.SwaggerDefinition;
 import org.opentosca.container.api.dto.ResourceSupport;
-import org.opentosca.deployment.checks.DeploymentTestService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestMapping;
 

--- a/org.opentosca.container.api/src/main/java/org/opentosca/container/api/controller/RootController.java
+++ b/org.opentosca.container.api/src/main/java/org/opentosca/container/api/controller/RootController.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.opentosca.container.api.controller;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -27,6 +28,7 @@ import io.swagger.annotations.Info;
 import io.swagger.annotations.License;
 import io.swagger.annotations.SwaggerDefinition;
 import org.opentosca.container.api.dto.ResourceSupport;
+import org.opentosca.deployment.checks.DeploymentTestService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -53,6 +55,8 @@ public class RootController {
         links.add(Link.fromResource(CsarController.class).rel("csars").baseUri(this.uriInfo.getBaseUri()).build());
         links.add(
             Link.fromResource(SituationsController.class).rel("situationsapi").baseUri(this.uriInfo.getBaseUri()).build());
+        links.add(
+            Link.fromResource(PlanbuilderController.class).rel("planbuilder").baseUri(this.uriInfo.getBaseUri()).build());
 
         return Response.ok(links).build();
     }

--- a/org.opentosca.container.api/src/main/java/org/opentosca/container/api/planbuilder/PlanbuilderWorker.java
+++ b/org.opentosca.container.api/src/main/java/org/opentosca/container/api/planbuilder/PlanbuilderWorker.java
@@ -191,9 +191,6 @@ public class PlanbuilderWorker {
             final List<String> inputParameters = ((BPELPlan) buildPlan).getWsdl().getInputMessageLocalNames();
             final List<String> outputParameters = ((BPELPlan) buildPlan).getWsdl().getOuputMessageLocalNames();
 
-            TPlan plan = new TPlan();
-
-
             final JsonObject obj = new JsonObject();
             obj.addProperty("name", QName.valueOf(buildPlan.getId()).getLocalPart());
             obj.addProperty("id", QName.valueOf(buildPlan.getId()).getLocalPart());
@@ -214,20 +211,8 @@ public class PlanbuilderWorker {
             outputParametersJson.add("outputParameter", outputParamList);
             obj.add("outputParameters", outputParametersJson);
 
-            System.out.println(obj.toString());
-
-            plan.setId(QName.valueOf(buildPlan.getId()).getLocalPart());
-            plan.setName(QName.valueOf(buildPlan.getId()).getLocalPart());
-            plan.setPlanType(buildPlan.getType().toString());
-            plan.setPlanLanguage(BPELPlan.bpelNamespace);
-
-            // TODO INPUT AND OUTPUT PARAMS
-
-
             final HttpEntity ent =
-               // EntityBuilder.create().setSerializable(plan).setContentType(ContentType.APPLICATION_JSON).build();
                 EntityBuilder.create().setText(obj.toString()).setContentType(ContentType.APPLICATION_JSON).build();
-
 
 
             HttpResponse createPlanResponse = null;
@@ -251,13 +236,6 @@ public class PlanbuilderWorker {
                 LOG.error("[{}] {}", state.currentState, state.currentMessage);
                 forceDelete(csarId);
                 return;
-            }
-
-            try{
-                String response = IOUtils.toString(createPlanResponse.getEntity().getContent(),"UTF-8");
-                System.out.println(response);
-            } catch (IOException e) {
-                e.printStackTrace();
             }
 
             String planLocation = state.getPostUrl() + "/" + QName.valueOf(buildPlan.getId()).getLocalPart();

--- a/org.opentosca.container.api/src/main/java/org/opentosca/container/api/service/PlanService.java
+++ b/org.opentosca.container.api/src/main/java/org/opentosca/container/api/service/PlanService.java
@@ -132,10 +132,10 @@ public class PlanService {
             .findFirst()
             .orElseThrow(() -> new NotFoundException("Plan \"" + planId + "\" could not be found"));
 
-        final String namespace = serviceTemplate.getTargetNamespace();
+
         final PlanDTO dto = new PlanDTO(plan);
 
-        dto.setId(new QName(namespace, plan.getId()).toString());
+        dto.setId(plan.getId());
         enhanceInputParameters(csar, serviceTemplate, serviceTemplateInstanceId, parameters);
         dto.setInputParameters(parameters);
 

--- a/org.opentosca.container.control/src/main/java/org/opentosca/container/control/impl/OpenToscaControlServiceImpl.java
+++ b/org.opentosca.container.control/src/main/java/org/opentosca/container/control/impl/OpenToscaControlServiceImpl.java
@@ -205,7 +205,12 @@ public class OpenToscaControlServiceImpl implements OpenToscaControlService {
         final List<TPlan> undeployedPlans = new ArrayList<>();
 
         // fallback to serviceTemplate NamespaceURI
-        final String namespace = plans.getTargetNamespace() == null ? "" : plans.getTargetNamespace();
+        String namespace = plans.getTargetNamespace();
+
+        if(namespace == null) {
+            namespace = serviceTemplate.getTargetNamespace();
+        }
+
         if (!planEngine.deployPlan(plan, namespace, csar)) {
                 undeployedPlans.add(plan);
         }

--- a/org.opentosca.container.engine.plan.plugin.bpel/src/main/java/org/opentosca/container/engine/plan/plugin/bpel/BpelPlanEnginePlugin.java
+++ b/org.opentosca.container.engine.plan.plugin.bpel/src/main/java/org/opentosca/container/engine/plan/plugin/bpel/BpelPlanEnginePlugin.java
@@ -269,19 +269,13 @@ public class BpelPlanEnginePlugin implements IPlanEnginePlanRefPluginService {
             return false;
         }
 
-        String namespace = planId.getNamespaceURI();
-
-        if(!(namespace != null && !namespace.isEmpty())){
-            namespace = storage.findById(csarId).entryServiceTemplate().getTargetNamespace();
-        }
-
-        Path planLocation = planLocationOnDisk(csarId, new QName(namespace, planId.getLocalPart()), planRef);
+        Path planLocation = planLocationOnDisk(csarId, planId, planRef);
         if (planLocation == null) {
             // diagnostics already in planLocationOnDisk
             return false;
         }
 
-        return this.deployPlanFile(planLocation, csarId, new QName(namespace, planId.getLocalPart()), new HashMap<String, String>());
+        return this.deployPlanFile(planLocation, csarId, planId, new HashMap<String, String>());
     }
 
     /**

--- a/org.opentosca.container.engine.plan/src/main/java/org/opentosca/container/engine/plan/impl/PlanEngineImpl.java
+++ b/org.opentosca.container.engine.plan/src/main/java/org/opentosca/container/engine/plan/impl/PlanEngineImpl.java
@@ -83,7 +83,7 @@ public class PlanEngineImpl implements IPlanEngineService {
             LOG.info("Found PlanModelPlugin for plan {}", plan.getId());
             return plugin.deployPlan(plan.getPlanModel(), csarId);
         }
-        final QName planId = new QName(targetNamespace, plan.getId());
+        final QName planId = QName.valueOf(plan.getId());
         LOG.debug("Created new management plan id " + planId);
         LOG.info("Searching PlanReferencePlugin for plan {} written in language {}", plan.getId(), language);
         final IPlanEnginePlanRefPluginService plugin = this.getRefPlugin(language);
@@ -111,7 +111,7 @@ public class PlanEngineImpl implements IPlanEngineService {
             LOG.info("Found PlanModelPlugin for plan {}", plan.getId());
             return plugin.undeployPlan(plan.getPlanModel(), csarId);
         }
-        final QName planId = new QName(targetNamespace, plan.getId());
+        final QName planId = QName.valueOf(plan.getId());
         LOG.debug("Created new management plan id" + planId);
         LOG.info("Searching PlanReferencePlugin for plan {}", plan.getId());
         final IPlanEnginePlanRefPluginService plugin = this.getRefPlugin(language);

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.integration/src/main/java/org/opentosca/planbuilder/export/WineryExporter.java
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.integration/src/main/java/org/opentosca/planbuilder/export/WineryExporter.java
@@ -356,7 +356,7 @@ public class WineryExporter extends AbstractExporter {
 
 
 
-        PlanId planId = new PlanId(plansId, new XmlId("{"+ servId.getNamespace()+"}" +QName.valueOf(generatedPlan.getId()).getLocalPart(), false));
+        PlanId planId = new PlanId(plansId, new XmlId(QName.valueOf(generatedPlan.getId()).getLocalPart(), false));
         RepositoryFileReference fileRef = new RepositoryFileReference(planId, planPath.getFileName().toString());
         repo.putContentToFile(fileRef, Files.newInputStream(planPath), MediaType.APPLICATION_ZIP);
 

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.integration/src/main/java/org/opentosca/planbuilder/integration/layer/AbstractImporter.java
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.integration/src/main/java/org/opentosca/planbuilder/integration/layer/AbstractImporter.java
@@ -23,6 +23,7 @@ import org.opentosca.planbuilder.model.plan.AbstractPlan;
 import org.opentosca.planbuilder.model.tosca.AbstractDefinitions;
 import org.opentosca.planbuilder.model.tosca.AbstractNodeTemplate;
 import org.opentosca.planbuilder.model.tosca.AbstractRelationshipTemplate;
+import org.opentosca.planbuilder.model.tosca.AbstractServiceTemplate;
 
 /**
  * <p>
@@ -113,13 +114,19 @@ public abstract class AbstractImporter {
         final AbstractSimplePlanBuilder backupPlanBuilder = new BPELBackupManagementProcessBuilder(pluginRegistry);
         final AbstractSimplePlanBuilder testPlanBuilder = new BPELTestManagementProcessBuilder(pluginRegistry);
 
-        plans.addAll(scalingPlanBuilder.buildPlans(csarName, defs));
-        plans.addAll(buildPlanBuilder.buildPlans(csarName, defs));
-        plans.addAll(terminationPlanBuilder.buildPlans(csarName, defs));
-        plans.addAll(freezePlanBuilder.buildPlans(csarName, defs));
-        plans.addAll(defreezePlanBuilder.buildPlans(csarName, defs));
-        plans.addAll(backupPlanBuilder.buildPlans(csarName, defs));
-        plans.addAll(testPlanBuilder.buildPlans(csarName, defs));
+
+        AbstractServiceTemplate servTemplate = defs.getServiceTemplates().iterator().next();
+
+
+        if(!servTemplate.hasBuildPlan() | !servTemplate.hasTerminationPlan()) {
+            plans.addAll(scalingPlanBuilder.buildPlans(csarName, defs));
+            plans.addAll(buildPlanBuilder.buildPlans(csarName, defs));
+            plans.addAll(terminationPlanBuilder.buildPlans(csarName, defs));
+            plans.addAll(freezePlanBuilder.buildPlans(csarName, defs));
+            plans.addAll(defreezePlanBuilder.buildPlans(csarName, defs));
+            plans.addAll(backupPlanBuilder.buildPlans(csarName, defs));
+            plans.addAll(testPlanBuilder.buildPlans(csarName, defs));
+        }
 
         return plans;
     }


### PR DESCRIPTION
- refactors handling of plan ids, it is now more aligned to winery which doesn't care about namespaces
- refactors plan generation to ignore namespaces as winery
- fixes planbuilder service to be able to be used in winery again
- fixes planbuilder to generate plans only when there are none (however is still rather rudimentary)
- fixes invocation of BPMN plans via the management bus
