### PR TITLE
fixes generating plan outputs which use the string concating function

### DIFF
--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/java/org/opentosca/planbuilder/core/bpel/tosca/handlers/ServiceTemplateBoundaryPropertyMappingsToOutputHandler.java
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/java/org/opentosca/planbuilder/core/bpel/tosca/handlers/ServiceTemplateBoundaryPropertyMappingsToOutputHandler.java
@@ -441,16 +441,13 @@ public class ServiceTemplateBoundaryPropertyMappingsToOutputHandler {
             if (functionPart.trim().startsWith("'")) {
                 // string function part, just add to list
                 augmentedFunctionParts.add(functionPart);
-            } else if (functionPart.trim().split("\\.").length == 3) {
+            } else if (functionPart.trim().split("\\.Properties\\.").length == 2) {
                 // "DSL" Query
-                final String[] queryParts = functionPart.trim().split("\\.");
-                // fast check for validity
-                if (!queryParts[1].equals("Properties")) {
-                    return null;
-                }
+                final String[] queryParts = functionPart.trim().split("\\.Properties\\.");
+
 
                 final String nodeTemplateName = queryParts[0];
-                final String propertyName = queryParts[2];
+                final String propertyName = queryParts[1];
 
                 boolean addedVar = false;
                 for (PropertyVariable var : propMap.getPropertyVariables(serviceTemplate, nodeTemplateName)) {

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.integration/src/main/java/org/opentosca/planbuilder/importer/winery/context/impl/impl/PropertyMappingImpl.java
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.integration/src/main/java/org/opentosca/planbuilder/importer/winery/context/impl/impl/PropertyMappingImpl.java
@@ -1,7 +1,7 @@
 package org.opentosca.planbuilder.importer.winery.context.impl.impl;
 
-import org.oasis_open.docs.tosca.ns._2011._12.TNodeTemplate;
-import org.oasis_open.docs.tosca.ns._2011._12.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
 import org.opentosca.planbuilder.model.tosca.AbstractPropertyMapping;
 
 /**


### PR DESCRIPTION
+ fixes OutputHandler to use right imports for NodeTemplate and RelationshipTemplate
+ fixes an issue with finding the right property when IDs used a '.'
