### PR TITLE
bump version of google guava to 30.0-jre and higher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
-				<version>29.0-jre</version>
+				<version>[30.0-jre,)</version>
 			</dependency>
 			<dependency>
 				<groupId>javax.ws.rs</groupId>


### PR DESCRIPTION
security fix reported by dependabot