### PR TITLE
Enhance Live-Modeling Performance: Enable using CSARs from a local Winery Repository 

### DIFF
--- a/org.opentosca.container.core/src/main/java/org/opentosca/container/core/common/Settings.java
+++ b/org.opentosca.container.core/src/main/java/org/opentosca/container/core/common/Settings.java
@@ -31,8 +31,9 @@ public class Settings {
 
     public final static String OPENTOSCA_CONTAINER_HOSTNAME = settings.getProperty("org.opentosca.container.hostname", "localhost");
     public final static String OPENTOSCA_CONTAINER_PORT = settings.getProperty("org.opentosca.container.port", "1337");
-    
-    public final static String CONTAINER_API = "http://" + Settings.OPENTOSCA_CONTAINER_HOSTNAME + ":" + Settings.OPENTOSCA_CONTAINER_PORT;    
+    public final static String OPENTOSCA_CONTAINER_LOCAL_WINERY_REPOSITORY = settings.getProperty("org.opentosca.container.winery.repository", null);
+
+    public final static String CONTAINER_API = "http://" + Settings.OPENTOSCA_CONTAINER_HOSTNAME + ":" + Settings.OPENTOSCA_CONTAINER_PORT;
     public final static String CONTAINER_INSTANCEDATA_API = "http://" + Settings.OPENTOSCA_CONTAINER_HOSTNAME + ":" + Settings.OPENTOSCA_CONTAINER_PORT + "/csars/{csarid}/servicetemplates/{servicetemplateid}/instances";
     public final static String OPENTOSCA_CONTAINER_CONTENT_API = "http://" + Settings.OPENTOSCA_CONTAINER_HOSTNAME + ":" + Settings.OPENTOSCA_CONTAINER_PORT + "/csars/{csarid}/content/";
     public final static String OPENTOSCA_CONTAINER_CONTENT_API_ARTIFACTREFERENCE = "http://" + Settings.OPENTOSCA_CONTAINER_HOSTNAME + ":" + Settings.OPENTOSCA_CONTAINER_PORT + "/csars/{csarid}/content/{artifactreference}";
@@ -53,7 +54,7 @@ public class Settings {
     public final static String OPENTOSCA_BUS_MANAGEMENT_MOCK = settings.getProperty("org.opentosca.bus.management.mocking", "false");
     public final static String OPENTOSCA_TEST_LOCAL_REPOSITORY_PATH = settings.getProperty("org.opentosca.test.local.repository.path");
     public final static String OPENTOSCA_TEST_REMOTE_REPOSITORY_URL = settings.getProperty("org.opentosca.test.remote.repository.url");
-    public final static Path CONTAINER_STORAGE_BASEPATH = Paths.get(System.getProperty("java.io.tmpdir"), "opentosca", "container", "csar-storage");
+    public final static Path CONTAINER_STORAGE_BASEPATH = settings.getProperty("org.opentosca.container.storage.basepath") != null && !settings.getProperty("org.opentosca.container.storage.basepath").isEmpty() ? Paths.get(settings.getProperty("org.opentosca.container.storage.basepath")) : Paths.get(System.getProperty("java.io.tmpdir"), "opentosca", "container", "csar-storage");
 
     /**
      * OpenTOSCA Container database location

--- a/org.opentosca.container.core/src/main/java/org/opentosca/container/core/model/csar/CsarImpl.java
+++ b/org.opentosca.container.core/src/main/java/org/opentosca/container/core/model/csar/CsarImpl.java
@@ -3,6 +3,8 @@ package org.opentosca.container.core.model.csar;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -91,7 +93,28 @@ public class CsarImpl implements Csar {
             qname = new String(Files.readAllBytes(csarLocation.resolve(ENTRY_SERVICE_TEMPLATE_LOCATION)), StandardCharsets.UTF_8);
         } catch (IOException e) {
             // Swallow, no helping this
+
+            // maybe a log could have helped for the future..
+            LOGGER.debug("Couldn't find entry service template in location " + csarLocation, e);
         }
+
+        try {
+
+
+        // or trying a little
+        if (Files.exists(csarLocation.resolve("ServiceTemplate.tosca"))){
+            // where now in the winery repository code here
+            String localName = csarLocation.getFileName().toString();
+            String namespaceEncoded = csarLocation.getParent().getFileName().toString();
+
+            String namespaceDecoded = URLDecoder.decode(namespaceEncoded, "UTF-8");
+
+            qname = "{" + namespaceDecoded + "}" +  localName;
+        }
+        } catch (UnsupportedEncodingException e) {
+            LOGGER.debug("Couldn't decode namespace in location " + csarLocation, e);
+        }
+
         return qname == null ? Optional.empty()
             : Optional.ofNullable(new ServiceTemplateId(QName.valueOf(qname)));
     }

--- a/org.opentosca.container.core/src/main/resources/application.properties
+++ b/org.opentosca.container.core/src/main/resources/application.properties
@@ -3,7 +3,7 @@
 org.opentosca.container.hostname=localhost
 org.opentosca.container.port=1337
 org.opentosca.container.storage.basepath=
-org.opentosca.container.winery.repository=/Users/iaas/Documents/gits/temp/tosca-definitions-internal
+org.opentosca.container.winery.repository=
 
 # IA Engine Configuration (endpoint and credentials)
 org.opentosca.container.engine.ia.hostname=localhost

--- a/org.opentosca.container.core/src/main/resources/application.properties
+++ b/org.opentosca.container.core/src/main/resources/application.properties
@@ -2,6 +2,8 @@
 # Your external IP adress, e.g. 129.69.214.56
 org.opentosca.container.hostname=localhost
 org.opentosca.container.port=1337
+org.opentosca.container.storage.basepath=
+org.opentosca.container.winery.repository=/Users/iaas/Documents/gits/temp/tosca-definitions-internal
 
 # IA Engine Configuration (endpoint and credentials)
 org.opentosca.container.engine.ia.hostname=localhost


### PR DESCRIPTION
#### Short Description
The Live-Modeling feature of the winery https://github.com/OpenTOSCA/winery/pull/230 enable users to model and "test" their deployment all within the Topology Modeler of the Winery.
However, at certain points in time a complete CSAR has to be uploaded to the Container (especially when the model changes), which when it is quite large, slows the performance of the feature.
The idea of this PR is to enable using a local winery git repository, enabling to use the Winery and Container on the same data, which in turn, allows us to remove uploading CSARs and therefore increase performance.

#### Proposed Changes
  * Add an additional CSAR storage implementation that can read all necessary data from a base winery repository
  * Enable the API to be able to present that data via REST, e.g., right now it is expected that all file paths are present just as in a CSAR, this is not the case in a winery repository (e.g. import elements are completely missing!)
  * Enable the container to generate plans when needed, meaning, when service templates change in the storage, old plans have to be regenerated and so on. Probably, we need to think about generating plans completely in an ad-hoc manner
 

