### PR TITLE
fixes a nullpointer when using a docker container 

### DIFF
--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.type.plugin.dockercontainer/src/main/java/org/opentosca/planbuilder/type/plugin/dockercontainer/bpel/handler/BPELDockerContainerTypePluginHandler.java
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.type.plugin.dockercontainer/src/main/java/org/opentosca/planbuilder/type/plugin/dockercontainer/bpel/handler/BPELDockerContainerTypePluginHandler.java
@@ -231,7 +231,7 @@ public class BPELDockerContainerTypePluginHandler implements DockerContainerType
             }
         }
 
-        if (containerImageVar == null || PluginUtils.isVariableValueEmpty(containerImageVar)) {
+        if ((containerImageVar == null || PluginUtils.isVariableValueEmpty(containerImageVar)) && (nodeTemplate.getDeploymentArtifacts() != null && !nodeTemplate.getDeploymentArtifacts().isEmpty())) {
             // handle with DA -> construct URL to the DockerImage .zip
 
             final TDeploymentArtifact da = fetchFirstDockerContainerDA(nodeTemplate, templateContext.getCsar());

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.type.plugin.dockercontainer/src/main/java/org/opentosca/planbuilder/type/plugin/dockercontainer/core/DockerContainerTypePlugin.java
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.type.plugin.dockercontainer/src/main/java/org/opentosca/planbuilder/type/plugin/dockercontainer/core/DockerContainerTypePlugin.java
@@ -34,6 +34,10 @@ public abstract class DockerContainerTypePlugin<T extends PlanContext> implement
     }
 
     public static TDeploymentArtifact getTDeploymentArtifact(TNodeTemplate nodeTemplate, Csar csar) {
+        if (nodeTemplate.getDeploymentArtifacts() == null) {
+            return null;
+        }
+
         for (final TDeploymentArtifact da : nodeTemplate.getDeploymentArtifacts()) {
             if (da.getArtifactType().equals(DockerContainerTypePluginPluginConstants.DOCKER_CONTAINER_ARTIFACTTYPE)
                 || da.getArtifactType()


### PR DESCRIPTION
node templates without a deployment artifact defined throw a nullpointer exception because the model delivers a null instead of an empty list