### PR TITLE
Always upload DAs to supported Infra Nodes

### DIFF
--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.prephase.plugin.fileupload/src/main/java/org/opentosca/planbuilder/prephase/plugin/fileupload/bpel/BPELPrePhasePlugin.java
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.prephase.plugin.fileupload/src/main/java/org/opentosca/planbuilder/prephase/plugin/fileupload/bpel/BPELPrePhasePlugin.java
@@ -170,9 +170,12 @@ public class BPELPrePhasePlugin implements IPlanBuilderPrePhasePlugin<BPELPlanCo
             return true;
         }
 
-        if (!org.opentosca.container.core.convention.Utils
-            .isSupportedInfrastructureNodeType(infrastructureNodeType)) {
+        if (!Utils.isSupportedInfrastructureNodeType(infrastructureNodeType)) {
             return false;
+        }
+        // else if we have a supported infrastructure node, and we are handling a DA, upload it...
+        if (isDA) {
+            return true;
         }
 
         // we can deploy on debian nodes (ubuntu, raspbian, docker containers based on


### PR DESCRIPTION
Currently, if a new ArtifactType is used as a DA type, then we must always adapt the orchestrator to support this new type. This PR should avoid this for DAs. IAs is a whole different subject...