### PR TITLE
Fix typos

### DIFF
--- a/org.opentosca.container.war/src/test/java/org/opentosca/container/war/tests/AdaptMultiMyTinyToDoIntegrationTest.java
+++ b/org.opentosca.container.war/src/test/java/org/opentosca/container/war/tests/AdaptMultiMyTinyToDoIntegrationTest.java
@@ -40,7 +40,7 @@ public class AdaptMultiMyTinyToDoIntegrationTest {
 
     public static final String TESTAPPLICATIONSREPOSITORY = "https://github.com/OpenTOSCA/tosca-definitions-test-applications";
 
-    public QName csarId = new QName("http://opentosca.org/test/applications/servicetemplates", "MutliMyTinyToDo-DockerEngine-Test_w1-wip1");
+    public QName csarId = new QName("http://opentosca.org/test/applications/servicetemplates", "MultiMyTinyToDo-DockerEngine-Test_w1-wip1");
 
     @Inject
     public OpenToscaControlService control;

--- a/org.opentosca.container.war/src/test/java/org/opentosca/container/war/tests/MigrateMyTinyToDo2MultiMyTinyToDoIntegrationTest.java
+++ b/org.opentosca.container.war/src/test/java/org/opentosca/container/war/tests/MigrateMyTinyToDo2MultiMyTinyToDoIntegrationTest.java
@@ -49,7 +49,7 @@ public class MigrateMyTinyToDo2MultiMyTinyToDoIntegrationTest {
     protected static final Logger LOGGER = LoggerFactory.getLogger(MigrateMyTinyToDo2MultiMyTinyToDoIntegrationTest.class);
 
     public QName myTinyToDocsarId = new QName("http://opentosca.org/test/applications/servicetemplates", "MyTinyToDo-DockerEngine-Test_w1-wip1");
-    public QName multiMyTinyToDoCsarId = new QName("http://opentosca.org/test/applications/servicetemplates", "MutliMyTinyToDo-DockerEngine-Test_w1-wip1");
+    public QName multiMyTinyToDoCsarId = new QName("http://opentosca.org/test/applications/servicetemplates", "MultiMyTinyToDo-DockerEngine-Test_w1-wip1");
 
     @Inject
     public OpenToscaControlService control;

--- a/org.opentosca.container.war/src/test/java/org/opentosca/container/war/tests/MultiMyTinyToDoIntegrationTest.java
+++ b/org.opentosca.container.war/src/test/java/org/opentosca/container/war/tests/MultiMyTinyToDoIntegrationTest.java
@@ -41,7 +41,7 @@ public class MultiMyTinyToDoIntegrationTest {
 
     public static final String TESTAPPLICATIONSREPOSITORY = "https://github.com/OpenTOSCA/tosca-definitions-test-applications";
 
-    public QName csarId = new QName("http://opentosca.org/test/applications/servicetemplates", "MutliMyTinyToDo-DockerEngine-Test_w1-wip1");
+    public QName csarId = new QName("http://opentosca.org/test/applications/servicetemplates", "MultiMyTinyToDo-DockerEngine-Test_w1-wip1");
 
     @Inject
     public OpenToscaControlService control;


### PR DESCRIPTION
Fix typos in QName of test ServiceTemplate

First, merge https://github.com/OpenTOSCA/tosca-definitions-test-applications/pull/1 and afterwards rerun the tests in this PR