### PR TITLE
fixes issue with generting scaling plans again although they are already available

### DIFF
--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/java/org/opentosca/planbuilder/core/bpel/typebasedplanbuilder/BPELScaleOutProcessBuilder.java
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/java/org/opentosca/planbuilder/core/bpel/typebasedplanbuilder/BPELScaleOutProcessBuilder.java
@@ -277,9 +277,15 @@ public class BPELScaleOutProcessBuilder extends AbstractScaleOutPlanBuilder {
 
         for (ScalingPlanDefinition scalingPlanDefinition : scalingPlanDefinitions) {
             boolean isAlreadyAvailable = false;
+            if (serviceTemplate.getPlans() == null) {
+                // there are no plans anyway
+                filteredScalingPlanDefinitions.addAll(scalingPlanDefinitions);
+                break;
+            }
             for (TPlan plan : serviceTemplate.getPlans()) {
                 if (plan.getId().endsWith(scalingPlanDefinition.name)) {
                     isAlreadyAvailable = true;
+                    break;
                 }
             }
             if (!isAlreadyAvailable) {

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/java/org/opentosca/planbuilder/core/bpel/typebasedplanbuilder/BPELScaleOutProcessBuilder.java
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/java/org/opentosca/planbuilder/core/bpel/typebasedplanbuilder/BPELScaleOutProcessBuilder.java
@@ -16,11 +16,13 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.winery.model.tosca.TDefinitions;
 import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TPlan;
 import org.eclipse.winery.model.tosca.TRelationshipTemplate;
 import org.eclipse.winery.model.tosca.TServiceTemplate;
 import org.eclipse.winery.model.tosca.TTag;
 import org.eclipse.winery.model.tosca.TTopologyTemplate;
 
+import com.google.common.collect.Lists;
 import org.opentosca.container.core.convention.Types;
 import org.opentosca.container.core.model.ModelUtils;
 import org.opentosca.container.core.model.csar.Csar;
@@ -271,8 +273,21 @@ public class BPELScaleOutProcessBuilder extends AbstractScaleOutPlanBuilder {
         final List<ScalingPlanDefinition> scalingPlanDefinitions =
             fetchScalingPlansDefinitions(serviceTemplate.getTopologyTemplate(), tagMap, csar);
 
-        for (final ScalingPlanDefinition scalingPlanDefinition : scalingPlanDefinitions) {
+        final List<ScalingPlanDefinition> filteredScalingPlanDefinitions = Lists.newArrayList();
 
+        for (ScalingPlanDefinition scalingPlanDefinition : scalingPlanDefinitions) {
+            boolean isAlreadyAvailable = false;
+            for (TPlan plan : serviceTemplate.getPlans()) {
+                if (plan.getId().endsWith(scalingPlanDefinition.name)) {
+                    isAlreadyAvailable = true;
+                }
+            }
+            if (!isAlreadyAvailable) {
+                filteredScalingPlanDefinitions.add(scalingPlanDefinition);
+            }
+        }
+
+        for (final ScalingPlanDefinition scalingPlanDefinition : filteredScalingPlanDefinitions) {
             final BPELPlan bpelScaleOutProcess = this.createScalingPlan(csar, definitions, serviceTemplate, scalingPlanDefinition);
 
             scalingPlans.add(bpelScaleOutProcess);

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/java/org/opentosca/planbuilder/core/bpel/typebasedplanbuilder/BPELScaleOutProcessBuilder.java
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.core.bpel/src/main/java/org/opentosca/planbuilder/core/bpel/typebasedplanbuilder/BPELScaleOutProcessBuilder.java
@@ -275,21 +275,22 @@ public class BPELScaleOutProcessBuilder extends AbstractScaleOutPlanBuilder {
 
         final List<ScalingPlanDefinition> filteredScalingPlanDefinitions = Lists.newArrayList();
 
-        for (ScalingPlanDefinition scalingPlanDefinition : scalingPlanDefinitions) {
-            boolean isAlreadyAvailable = false;
-            if (serviceTemplate.getPlans() == null) {
-                // there are no plans anyway
-                filteredScalingPlanDefinitions.addAll(scalingPlanDefinitions);
-                break;
-            }
-            for (TPlan plan : serviceTemplate.getPlans()) {
-                if (plan.getId().endsWith(scalingPlanDefinition.name)) {
-                    isAlreadyAvailable = true;
-                    break;
+        if (serviceTemplate.getPlans() == null) {
+            // there are no plans anyway
+            filteredScalingPlanDefinitions.addAll(scalingPlanDefinitions);
+        } else {
+            for (ScalingPlanDefinition scalingPlanDefinition : scalingPlanDefinitions) {
+                boolean isAlreadyAvailable = false;
+
+                for (TPlan plan : serviceTemplate.getPlans()) {
+                    if (plan.getId().endsWith(scalingPlanDefinition.name)) {
+                        isAlreadyAvailable = true;
+                        break;
+                    }
                 }
-            }
-            if (!isAlreadyAvailable) {
-                filteredScalingPlanDefinitions.add(scalingPlanDefinition);
+                if (!isAlreadyAvailable) {
+                    filteredScalingPlanDefinitions.add(scalingPlanDefinition);
+                }
             }
         }
 

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.integration/src/main/java/org/opentosca/planbuilder/integration/layer/AbstractImporter.java
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.integration/src/main/java/org/opentosca/planbuilder/integration/layer/AbstractImporter.java
@@ -174,7 +174,7 @@ public abstract class AbstractImporter {
             plans.addAll(testPlanBuilder.buildPlans(csar, defs));
         }
 
-        // hard to check honestly, TODO check if there are scaling plan definitions and if they are already available in the TOSCA interface of the service template
+        // the check whether plans have to be generated is inside the plan builder as it is highly contextual
         plans.addAll(scalingPlanBuilder.buildPlans(csar, defs));
 
         return plans;


### PR DESCRIPTION
**Fixes**: #294 
However it seems it didn't work only for scale out plans, but thats fixed now. Can't reproduce for other plans.
Tested with the following CSAR: https://drive.google.com/file/d/1V0nwhw_axdsohr83MCnj48JLhfEsYcUe/view?usp=sharing