### PR TITLE
fixes an error when there are no properties defined in a NodeTemplate

### DIFF
--- a/org.opentosca.container.api/src/main/java/org/opentosca/container/api/controller/BuildPlanController.java
+++ b/org.opentosca.container.api/src/main/java/org/opentosca/container/api/controller/BuildPlanController.java
@@ -160,6 +160,10 @@ public class BuildPlanController {
         LOGGER.debug("Invoking getBuildPlanInstance");
         PlanInstance pi = planInstanceService.getPlanInstanceByCorrelationIdWithConnectedEntities(instance);
 
+        if (pi == null) {
+            return Response.status(Status.NOT_FOUND).build();
+        }
+
         final PlanInstanceDTO dto = PlanInstanceDTO.Converter.convert(pi);
         // Add service template instance link
         if (pi.getServiceTemplateInstance() != null) {

--- a/org.opentosca.container.core/src/main/java/org/opentosca/container/core/next/xml/PropertyParser.java
+++ b/org.opentosca.container.core/src/main/java/org/opentosca/container/core/next/xml/PropertyParser.java
@@ -58,6 +58,14 @@ public final class PropertyParser {
             final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setNamespaceAware(true);
             final DocumentBuilder builder = factory.newDocumentBuilder();
+            if (!xml.contains("<Properties") && !xml.contains("<tosca:Properties")) {
+                // some NodeTemplate may have no Properties defined meaning
+                // we have an empty XML document (only <?xml... inside)
+                // which breaks the parser as there is no root element defined
+                Document doc = builder.newDocument();
+                doc.appendChild(doc.createElement("Properties"));
+                return doc;
+            }
             return builder.parse(new InputSource(new StringReader(xml)));
         } catch (final Exception e) {
             logger.error("Error parsing XML string", e);


### PR DESCRIPTION
#### Short Description
If there are no Properties defined on a NodeTemplate (and literally no Properties element inside a TOSCA document) the parsing of properties fail
