### PR TITLE
Removes unneccessary Java 8 IA Engine

### DIFF
--- a/test.yml
+++ b/test.yml
@@ -1,9 +1,5 @@
 version: '3'
 services:
-  engine-ia-java8:
-    image: opentosca/engine-ia:latest-jdk8
-    ports:
-      - '8098:8080'
   engine-ia-java17:
     image: opentosca/engine-ia:latest-jdk17
     ports:


### PR DESCRIPTION
Removes unneccessary Java 8 IA Engine from test.yaml, as it is said that we don't need it anymore
