### PR TITLE
Fix/connect to

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,6 +38,7 @@ jobs:
         test:
           - AdaptMultiMyTinyToDoIntegrationTest
           - ApacheWebAppIntegrationTest
+          - ConnectToIntegrationTest
           - MigrateMyTinyToDo2MultiMyTinyToDoIntegrationTest
           - MultiMyTinyToDoIntegrationTest
           - MyTinyToDoBPMNIntegrationTest

--- a/docs/components/PlanBuilder.md
+++ b/docs/components/PlanBuilder.md
@@ -91,10 +91,13 @@ Additionally, if the connectTo operation is under an interface with name http://
 1. If B has a start or stop operation under a lifecycle interface, before calling the connectTo operation the stop operation on B is called and after the connectTo operation the start operation is called.
 2. If A has a start or stop operation under a lifecycle interface, before calling the connectTo operation the stop operation on B is called and after the connectTo operation the start operation is called.
 
-To circumvent that the connectTo is invoked multiple times on a target node if it connects to another node as a source node use the following naming convention:
+## Naming convention
 
-1. Whenever the node is the source node: http://opentosca.org/interfaces/connections/source/{type_without_version}
-2. Whenever the node is the target node: http://opentosca.org/interfaces/connections/target/{type_without_version}
+To circumvent that the `ConnectTo` operation is invoked multiple times on a target node if it connects to another node as a source node use the following naming convention where `{type_without_version}` is considered to be the only `name/id` without double encoding:
+
+1. Whenever the node is the source node: `http://opentosca.org/interfaces/connections/source/{type_without_version}`
+2. Whenever the node is the target node: `http://opentosca.org/interfaces/connections/target/{type_without_version}`
+
 
 It is the recommended way to use the connectsTo operation as it also prevents error when the source node has multiple connectsTo with the same properties.
 

--- a/docs/components/PlanBuilder.md
+++ b/docs/components/PlanBuilder.md
@@ -91,3 +91,10 @@ Additionally, if the connectTo operation is under an interface with name http://
 1. If B has a start or stop operation under a lifecycle interface, before calling the connectTo operation the stop operation on B is called and after the connectTo operation the start operation is called.
 2. If A has a start or stop operation under a lifecycle interface, before calling the connectTo operation the stop operation on B is called and after the connectTo operation the start operation is called.
 
+To circumvent that the connectTo is invoked multiple times on a target node if it connects to another node as a source node use the following naming convention:
+
+1. Whenever the node is the source node: http://opentosca.org/interfaces/connections/source/{type_without_version}
+2. Whenever the node is the target node: http://opentosca.org/interfaces/connections/target/{type_without_version}
+
+It is the recommended way to use the connectsTo operation as it also prevents error when the source node has multiple connectsTo with the same properties.
+

--- a/org.opentosca.container.war/src/test/java/org/opentosca/container/war/tests/ConnectToIntegrationTest.java
+++ b/org.opentosca.container.war/src/test/java/org/opentosca/container/war/tests/ConnectToIntegrationTest.java
@@ -43,7 +43,7 @@ public class ConnectToIntegrationTest {
 
     public static final String TESTAPPLICATIONSREPOSITORY = "https://github.com/OpenTOSCA/tosca-definitions-test-applications";
 
-    public QName csarId = QName.valueOf("{http://opentosca.org/test/applications/servicetemplates}ConnectTo-Test-Application_w1-wip1");
+    public QName csarId = QName.valueOf("{http://opentosca.org/test/applications/servicetemplates}ConnectTo-Test-Application_w1");
     @Inject
     public OpenToscaControlService control;
     @Inject

--- a/org.opentosca.container.war/src/test/java/org/opentosca/container/war/tests/ConnectToIntegrationTest.java
+++ b/org.opentosca.container.war/src/test/java/org/opentosca/container/war/tests/ConnectToIntegrationTest.java
@@ -1,0 +1,150 @@
+package org.opentosca.container.war.tests;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import javax.inject.Inject;
+import javax.xml.namespace.QName;
+
+import org.eclipse.winery.model.tosca.TPlan;
+import org.eclipse.winery.model.tosca.TServiceTemplate;
+
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentosca.container.api.service.PlanInvokerService;
+import org.opentosca.container.control.OpenToscaControlService;
+import org.opentosca.container.control.plan.PlanGenerationService;
+import org.opentosca.container.core.extension.TParameter;
+import org.opentosca.container.core.model.csar.Csar;
+import org.opentosca.container.core.next.model.ServiceTemplateInstance;
+import org.opentosca.container.core.next.model.ServiceTemplateInstanceState;
+import org.opentosca.container.core.next.services.instances.NodeTemplateInstanceService;
+import org.opentosca.container.core.next.services.instances.PlanInstanceService;
+import org.opentosca.container.core.next.services.instances.RelationshipTemplateInstanceService;
+import org.opentosca.container.core.next.services.instances.ServiceTemplateInstanceService;
+import org.opentosca.container.core.service.CsarStorageService;
+import org.opentosca.container.core.service.ICoreEndpointService;
+import org.opentosca.container.war.Application;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, classes = {Application.class}, properties = "spring.main.allow-bean-definition-overriding=true")
+@TestPropertySource(properties = "server.port=1337")
+public class ConnectToIntegrationTest {
+
+    public static final String TESTAPPLICATIONSREPOSITORY = "https://github.com/OpenTOSCA/tosca-definitions-test-applications";
+
+    public QName csarId = QName.valueOf("{http://opentosca.org/test/applications/servicetemplates}ConnectTo-Test-Application_w1-wip1");
+    @Inject
+    public OpenToscaControlService control;
+    @Inject
+    public CsarStorageService storage;
+    @Inject
+    public PlanGenerationService planGenerationService;
+    @Inject
+    public PlanInstanceService planInstanceService;
+    @Inject
+    public PlanInvokerService planInvokerService;
+    @Inject
+    public ServiceTemplateInstanceService serviceTemplateInstanceService;
+    @Inject
+    public RelationshipTemplateInstanceService relationshipTemplateInstanceService;
+    @Inject
+    public NodeTemplateInstanceService nodeTemplateInstanceService;
+    @Inject
+    public ICoreEndpointService endpointService;
+    private TestUtils testUtils = new TestUtils();
+
+    @Test
+    public void testDeployment() throws Exception {
+        Csar csar = testUtils.setupCsarTestRepository(this.csarId, this.storage, TESTAPPLICATIONSREPOSITORY);
+        testUtils.generatePlans(this.planGenerationService, csar);
+
+        TServiceTemplate serviceTemplate = csar.entryServiceTemplate();
+        assertNotNull(serviceTemplate);
+
+        List<TPlan> plans = serviceTemplate.getPlans();
+        assertNotNull(plans);
+
+        TPlan buildPlan = testUtils.getBuildPlan(plans);
+        TPlan terminationPlan = testUtils.getTerminationPlan(plans);
+        assertNotNull(buildPlan);
+        assertNotNull(terminationPlan);
+
+        testUtils.invokePlanDeployment(this.control, csar.id(), serviceTemplate);
+
+        assertEquals(2, testUtils.getDeployedPlans(this.endpointService).size());
+
+        ServiceTemplateInstance serviceTemplateInstance = testUtils.runBuildPlanExecution(this.planInstanceService,
+            this.planInvokerService, this.serviceTemplateInstanceService, csar, serviceTemplate, buildPlan, this.getBuildPlanInputParameters()
+        );
+
+        assertNotNull(serviceTemplateInstance);
+        assertEquals(ServiceTemplateInstanceState.CREATED, serviceTemplateInstance.getState());
+
+        HttpClient httpClient = HttpClient.newHttpClient();
+        HttpResponse<String> connectAResponse = httpClient.sendAsync(
+                HttpRequest.newBuilder(URI.create("http://localhost:9999/connectToA.txt")).build(),
+                HttpResponse.BodyHandlers.ofString())
+            .join();
+        assertEquals(200, connectAResponse.statusCode());
+        String stringA = connectAResponse.body();
+        // Check number of lines, each connectTo adds one line
+        assertEquals(1, stringA.split("[\n\r]").length);
+
+        HttpResponse<String> connectBResponse = httpClient.sendAsync(
+                HttpRequest.newBuilder(URI.create("http://localhost:9999/connectToB.txt")).build(),
+                HttpResponse.BodyHandlers.ofString())
+            .join();
+        assertEquals(200, connectBResponse.statusCode());
+        String stringB = connectBResponse.body();
+        assertEquals(1, stringB.split("[\n\r]").length);
+
+        testUtils.runTerminationPlanExecution(this.planInstanceService, this.planInvokerService, csar, serviceTemplate, serviceTemplateInstance, terminationPlan);
+
+        testUtils.invokePlanUndeployment(this.control, csar.id(), serviceTemplate);
+
+        assertEquals(0, testUtils.getDeployedPlans(this.endpointService).size());
+    }
+
+    @After
+    public void cleanUpContainer() {
+        testUtils.clearContainer(this.storage, this.control, this.planInstanceService,
+            this.relationshipTemplateInstanceService, this.nodeTemplateInstanceService,
+            this.serviceTemplateInstanceService);
+    }
+
+    private List<TParameter> getBuildPlanInputParameters() {
+        List<TParameter> baseInputParams = testUtils.getBaseInputParams();
+
+        TParameter dockerInDocker = new TParameter();
+        dockerInDocker.setName("DockerEngineURL");
+        dockerInDocker.setRequired(true);
+        dockerInDocker.setType("String");
+        dockerInDocker.setValue("tcp://" + testUtils.getDockerHost() + ":2375");
+        baseInputParams.add(dockerInDocker);
+
+        TParameter port = new TParameter();
+        port.setName("Port");
+        port.setRequired(true);
+        port.setType("String");
+        port.setValue("9999");
+        baseInputParams.add(port);
+
+        return baseInputParams;
+    }
+}

--- a/org.opentosca.container.war/src/test/java/org/opentosca/container/war/tests/ConnectToIntegrationTest.java
+++ b/org.opentosca.container.war/src/test/java/org/opentosca/container/war/tests/ConnectToIntegrationTest.java
@@ -5,8 +5,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.List;
-import java.util.Optional;
-import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 import javax.xml.namespace.QName;
@@ -14,8 +12,6 @@ import javax.xml.namespace.QName;
 import org.eclipse.winery.model.tosca.TPlan;
 import org.eclipse.winery.model.tosca.TServiceTemplate;
 
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,7 +35,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, classes = {Application.class}, properties = "spring.main.allow-bean-definition-overriding=true")

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.type.plugin.connectsto/src/main/java/org/opentosca/planbuilder/type/plugin/connectsto/bpel/handler/BPELConnectsToPluginHandler.java
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.type.plugin.connectsto/src/main/java/org/opentosca/planbuilder/type/plugin/connectsto/bpel/handler/BPELConnectsToPluginHandler.java
@@ -41,12 +41,12 @@ public class BPELConnectsToPluginHandler implements ConnectsToPluginHandler<BPEL
         final TNodeTemplate targetNodeTemplate = ModelUtils.getTarget(relationTemplate, templateContext.getCsar());
 
         if (checkExecution(templateContext.getCsar(), sourceNodeTemplate, ExecutionRole.SOURCE)) {
-            handleConnectsTo(sourceNodeTemplate, targetNodeTemplate, templateContext);
+            handleConnectsTo(sourceNodeTemplate, sourceNodeTemplate, targetNodeTemplate, templateContext);
         } else if (checkExecution(templateContext.getCsar(), sourceNodeTemplate, ExecutionRole.TARGET)) {
-            handleConnectsTo(targetNodeTemplate, sourceNodeTemplate, templateContext);
+            handleConnectsTo(targetNodeTemplate, sourceNodeTemplate, targetNodeTemplate, templateContext);
         } else {
-            handleConnectsTo(targetNodeTemplate, sourceNodeTemplate, templateContext);
-            handleConnectsTo(sourceNodeTemplate, targetNodeTemplate, templateContext);
+            handleConnectsTo(targetNodeTemplate, sourceNodeTemplate, targetNodeTemplate, templateContext);
+            handleConnectsTo(sourceNodeTemplate, sourceNodeTemplate, targetNodeTemplate, templateContext);
         }
 
         return true;
@@ -56,10 +56,11 @@ public class BPELConnectsToPluginHandler implements ConnectsToPluginHandler<BPEL
      * Handles the execution of a connectsTo operation including start and stop of the node
      *
      * @param nodeTemplateForExecution  connectsTo logic is executed on this node template
-     * @param nodeTemplateForConnection the remote node template to which the connection gets established
+     * @param sourceNodeTemplate        node template of source node
+     * @param targetNodeTemplate        node template of target node
      * @param templateContext           the context of this operation call
      */
-    private void handleConnectsTo(TNodeTemplate nodeTemplateForExecution, TNodeTemplate nodeTemplateForConnection, BPELPlanContext templateContext) {
+    private void handleConnectsTo(TNodeTemplate nodeTemplateForExecution, TNodeTemplate sourceNodeTemplate, TNodeTemplate targetNodeTemplate, BPELPlanContext templateContext) {
         if (hasOperation(nodeTemplateForExecution, Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_CONNECT_CONNECTTO, templateContext.getCsar())) {
             // if we can stop and start the node, and it is not defined as non-interruptive, stop it
             if (!ModelUtils.hasInterface(nodeTemplateForExecution, Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_CONNECT_NON_INTERRUPTIVE, templateContext.getCsar())
@@ -71,7 +72,7 @@ public class BPELConnectsToPluginHandler implements ConnectsToPluginHandler<BPEL
             }
 
             // connectTo
-            executeConnectsTo(templateContext, nodeTemplateForExecution, nodeTemplateForConnection, nodeTemplateForExecution);
+            executeConnectsTo(templateContext, nodeTemplateForExecution, sourceNodeTemplate, targetNodeTemplate);
 
             // start the node again
             if (!ModelUtils.hasInterface(nodeTemplateForExecution, Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_CONNECT_NON_INTERRUPTIVE, templateContext.getCsar())

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.type.plugin.connectsto/src/main/java/org/opentosca/planbuilder/type/plugin/connectsto/bpel/handler/BPELConnectsToPluginHandler.java
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.type.plugin.connectsto/src/main/java/org/opentosca/planbuilder/type/plugin/connectsto/bpel/handler/BPELConnectsToPluginHandler.java
@@ -1,5 +1,6 @@
 package org.opentosca.planbuilder.type.plugin.connectsto.bpel.handler;
 
+import java.lang.annotation.Target;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +40,16 @@ public class BPELConnectsToPluginHandler implements ConnectsToPluginHandler<BPEL
         final TRelationshipTemplate relationTemplate = templateContext.getRelationshipTemplate();
         final TNodeTemplate sourceNodeTemplate = ModelUtils.getSource(relationTemplate, templateContext.getCsar());
         final TNodeTemplate targetNodeTemplate = ModelUtils.getTarget(relationTemplate, templateContext.getCsar());
+
+
+        List<TInterface> sourceInterfaces = ModelUtils.findNodeType(sourceNodeTemplate, templateContext.getCsar()).getInterfaces();
+        if(executeOn(sourceInterfaces, sourceNodeTemplate, "source")){
+            System.out.println("Execute on source");
+        }
+        List<TInterface> targetInterfaces = ModelUtils.findNodeType(targetNodeTemplate, templateContext.getCsar()).getInterfaces();
+        if(executeOn(targetInterfaces, sourceNodeTemplate, "target")){
+            System.out.println("Execute on target");
+        }
 
         // if the target has connectTo we execute it
         if (hasOperation(targetNodeTemplate, Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_CONNECT_CONNECTTO, templateContext.getCsar())) {
@@ -416,5 +427,28 @@ public class BPELConnectsToPluginHandler implements ConnectsToPluginHandler<BPEL
             }
         }
         return true;
+    }
+
+    private boolean executeOn(List<TInterface> interfaces, TNodeTemplate nodeTemplate, String targetNode){
+        if (interfaces != null) {
+            for (final TInterface iface : interfaces) {
+                for (final TOperation op : iface.getOperations()) {
+                    if (op.getName().equals(Interfaces.OPENTOSCA_DECLARATIVE_INTERFACE_CONNECT_CONNECTTO)) {
+                        System.out.println(iface.getName());
+                        final String[] split = iface.getName().split("/");
+                        if(split.length>=2){
+                            final String nodeType = split[split.length - 1];
+                            final String sourceOrTarget = split[split.length -2];
+                            if(sourceOrTarget.equals(targetNode) && nodeTemplate.getType().getLocalPart().split("_")[0].equals(nodeType)){
+                                return true;
+                            }
+
+                        }
+
+                    }
+                }
+            }
+        }
+        return false;
     }
 }

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.type.plugin.connectsto/src/main/java/org/opentosca/planbuilder/type/plugin/connectsto/bpel/handler/BPELConnectsToPluginHandler.java
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.type.plugin.connectsto/src/main/java/org/opentosca/planbuilder/type/plugin/connectsto/bpel/handler/BPELConnectsToPluginHandler.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.eclipse.winery.common.version.VersionUtils;
 import org.eclipse.winery.model.tosca.TInterface;
 import org.eclipse.winery.model.tosca.TNodeTemplate;
 import org.eclipse.winery.model.tosca.TNodeType;
@@ -123,7 +124,7 @@ public class BPELConnectsToPluginHandler implements ConnectsToPluginHandler<BPEL
                                 continue;
                             }
                             if (!iface.getName().endsWith("/source")) {
-                                final String targetTypeWithoutVersion = targetParameterNode.getType().getLocalPart().split("_")[0];
+                                final String targetTypeWithoutVersion = VersionUtils.getNameWithoutVersion(targetParameterNode.getType().getLocalPart());
                                 if (!iface.getName().endsWith(targetTypeWithoutVersion)) {
                                     BPELConnectsToPluginHandler.LOG.debug("target type does not match");
                                     continue;
@@ -136,7 +137,7 @@ public class BPELConnectsToPluginHandler implements ConnectsToPluginHandler<BPEL
                                 continue;
                             }
                             if (!iface.getName().endsWith("/target")) {
-                                final String sourceTypeWithoutVersion = sourceParameterNode.getType().getLocalPart().split("_")[0];
+                                final String sourceTypeWithoutVersion = VersionUtils.getNameWithoutVersion(sourceParameterNode.getType().getLocalPart());
                                 if (!iface.getName().endsWith(sourceTypeWithoutVersion)) {
                                     BPELConnectsToPluginHandler.LOG.debug("source type does not match");
                                     continue;

--- a/org.opentosca.planbuilder/org.opentosca.planbuilder.type.plugin.connectsto/src/main/java/org/opentosca/planbuilder/type/plugin/connectsto/bpel/handler/BPELConnectsToPluginHandler.java
+++ b/org.opentosca.planbuilder/org.opentosca.planbuilder.type.plugin.connectsto/src/main/java/org/opentosca/planbuilder/type/plugin/connectsto/bpel/handler/BPELConnectsToPluginHandler.java
@@ -118,7 +118,7 @@ public class BPELConnectsToPluginHandler implements ConnectsToPluginHandler<BPEL
                         BPELConnectsToPluginHandler.LOG.debug(iface.getName());
                         if (iface.getName().matches(".*/source(/[^/]+)?$")) {
                             BPELConnectsToPluginHandler.LOG.debug("connectTo source defined");
-                            if (!connectToNode.equals(sourceParameterNode)){
+                            if (!connectToNode.equals(sourceParameterNode)) {
                                 BPELConnectsToPluginHandler.LOG.debug("source does not match");
                                 continue;
                             }
@@ -129,10 +129,9 @@ public class BPELConnectsToPluginHandler implements ConnectsToPluginHandler<BPEL
                                     continue;
                                 }
                             }
-
                         } else if (iface.getName().matches(".*/target(/[^/]+)?$")) {
                             BPELConnectsToPluginHandler.LOG.debug("connectTo target defined");
-                            if (!connectToNode.equals(targetParameterNode)){
+                            if (!connectToNode.equals(targetParameterNode)) {
                                 BPELConnectsToPluginHandler.LOG.debug("target does not match");
                                 continue;
                             }
@@ -143,7 +142,6 @@ public class BPELConnectsToPluginHandler implements ConnectsToPluginHandler<BPEL
                                     continue;
                                 }
                             }
-
                         }
                         BPELConnectsToPluginHandler.LOG.debug("Execute");
                         connectsToIface = iface;


### PR DESCRIPTION
#### Short Description
Fixes https://github.com/OpenTOSCA/container/issues/296

#### Proposed Changes
The interface of a connectTo operation can have the following form: `http://opentosca.org/interfaces/connections/{source|target}/{nodeType}`

- `{source|target}` specifies whether the operation should be only executed on the source or target
- `nodeType` is optional, and it defines the type of the remote node.

Interface names that do not follow this pattern are handled as before.

