### PR TITLE
GitHub registry

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -39,7 +39,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         if: ${{ steps.vars.outputs.tag == 'master' }}
-                uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v4
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -11,31 +11,38 @@ on:
     tags:
       - "v*.*.*"
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   multi:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set output
-        id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/setup-qemu-action@v2
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-
-      - name: Build and push latest Container
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
         if: ${{ steps.vars.outputs.tag == 'master' }}
-        uses: docker/build-push-action@v2
+                uses: docker/build-push-action@v4
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: opentosca/container:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -38,7 +38,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        if: ${{ steps.vars.outputs.tag == 'master' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/dockerhub_stable.yml
+++ b/.github/workflows/dockerhub_stable.yml
@@ -6,29 +6,37 @@ on:
     tags:
       - "v*.*.*"
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   multi:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set branch name output
-        id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/setup-qemu-action@v2
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push version of Container
-        uses: docker/build-push-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v4
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: opentosca/container:${{ steps.vars.outputs.tag }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,8 +1,13 @@
-# This workflow will build the Container and push a corresponding Docker image to Dockerhub
-name: Push stable docker image to Dockerhub
+# This workflow will build the Container and push a corresponding Docker image to the GitHub registry
+name: Push docker image to the GitHub registry
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - Java CI with Maven
+    branches: [master]
+    types:
+      - completed
     tags:
       - "v*.*.*"
 
@@ -12,6 +17,7 @@ env:
 
 jobs:
   multi:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -31,8 +37,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build and push
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/image_stable.yml
+++ b/.github/workflows/image_stable.yml
@@ -1,13 +1,8 @@
-# This workflow will build the Container and push a corresponding Docker image to Dockerhub
-name: Push docker image to Dockerhub
+# This workflow will build the Container and push a corresponding Docker image to the GitHub registry
+name: Push stable docker image to the GitHub registry
 
 on:
-  workflow_run:
-    workflows:
-      - Java CI with Maven
-    branches: [master]
-    types:
-      - completed
+  push:
     tags:
       - "v*.*.*"
 
@@ -17,7 +12,6 @@ env:
 
 jobs:
   multi:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,8 +31,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push
-        if: ${{ github.ref == 'refs/heads/master' }}
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,17 +35,17 @@ jobs:
   tests:
     strategy:
       matrix:
-        test:
-          - AdaptMultiMyTinyToDoIntegrationTest
-          - ApacheWebAppIntegrationTest
-          - ConnectToIntegrationTest
-          - MigrateMyTinyToDo2MultiMyTinyToDoIntegrationTest
-          - MultiMyTinyToDoIntegrationTest
-          - MyTinyToDoBPMNIntegrationTest
-          - MyTinyToDoIntegrationTest
+        test: # TODO: reenable tests
+          # - AdaptMultiMyTinyToDoIntegrationTest
+          # - ApacheWebAppIntegrationTest
+          # - ConnectToIntegrationTest
+          # - MigrateMyTinyToDo2MultiMyTinyToDoIntegrationTest
+          # - MultiMyTinyToDoIntegrationTest
+          # - MyTinyToDoBPMNIntegrationTest
+          # - MyTinyToDoIntegrationTest
           #- MyTinyToDoSqlIntegrationTest
           #- PlanQKServiceIntegrationTest
-          - QHAnaTest
+          # - QHAnaTest
     runs-on: ubuntu-latest
     timeout-minutes: 80
     needs: build

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,7 +35,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        test: # TODO: reenable tests
+        test: [] # TODO: reenable tests
           # - AdaptMultiMyTinyToDoIntegrationTest
           # - ApacheWebAppIntegrationTest
           # - ConnectToIntegrationTest

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,77 +32,76 @@ jobs:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: org.opentosca.container.reporting/target/site/jacoco-aggregate/jacoco.xml
 
-# TODO: reenable tests
-  # tests:
-  #   strategy:
-  #     matrix:
-  #       test: 
-  #         - AdaptMultiMyTinyToDoIntegrationTest
-  #         - ApacheWebAppIntegrationTest
-  #         - ConnectToIntegrationTest
-  #         - MigrateMyTinyToDo2MultiMyTinyToDoIntegrationTest
-  #         - MultiMyTinyToDoIntegrationTest
-  #         - MyTinyToDoBPMNIntegrationTest
-  #         - MyTinyToDoIntegrationTest
-  #         #- MyTinyToDoSqlIntegrationTest
-  #         #- PlanQKServiceIntegrationTest
-  #         - QHAnaTest
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 80
-  #   needs: build
+  tests:
+    strategy:
+      matrix:
+        test: 
+          - AdaptMultiMyTinyToDoIntegrationTest
+          - ApacheWebAppIntegrationTest
+          - ConnectToIntegrationTest
+          - MigrateMyTinyToDo2MultiMyTinyToDoIntegrationTest
+          - MultiMyTinyToDoIntegrationTest
+          - MyTinyToDoBPMNIntegrationTest
+          - MyTinyToDoIntegrationTest
+          #- MyTinyToDoSqlIntegrationTest
+          #- PlanQKServiceIntegrationTest
+          - QHAnaTest
+    runs-on: ubuntu-latest
+    timeout-minutes: 80
+    needs: build
 
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Set up JDK 17
-  #     uses: actions/setup-java@v3
-  #     with:
-  #       java-version: 17
-  #       cache: maven
-  #       distribution: temurin
-  #   - name: Check out TOSCA internal repository
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: OpenTOSCA/tosca-definitions-test-applications
-  #       ref: 'main'
-  #       path: 'tosca-definitions-test-applications'
-  #       lfs: 'true'
-  #   - name: Copy TOSCA internal repository to tmp
-  #     run: cp -R $GITHUB_WORKSPACE/tosca-definitions-test-applications /tmp/
-  #   - name: Show TOSCA internal repository content
-  #     run: ls -a /tmp/tosca-definitions-test-applications
-  #   - name: Setup Docker Remote API
-  #     run: sudo sed -ie "s@ExecStart=\/usr\/bin\/dockerd -H fd:\/\/@ExecStart=\/usr\/bin\/dockerd -H fd:\/\/ -H tcp:\/\/0.0.0.0:2375 -H unix:///var/run/docker.sock@g" /lib/systemd/system/docker.service
-  #   - name: Reload Daemons
-  #     run: sudo systemctl daemon-reload
-  #   - name: Restart Docker
-  #     run: sudo service docker restart
-  #   - name: Configure runtime with test properties
-  #     run: cp test.properties ./org.opentosca.container.core/src/main/resources/application.properties
-  #   - name: Show application properties
-  #     run: cat ./org.opentosca.container.core/src/main/resources/application.properties
-  #   - name: Test Docker Remote API
-  #     run: curl -X GET http://localhost:2375/images/json
-  #   - name: Start test environment
-  #     run: docker-compose -f test.yml up -d
-  #   - name: Save engine-ia-java17 log to file
-  #     run: docker-compose -f test.yml logs -f engine-ia-java17 > engine-ia-java17.log &
-  #   - name: Save engine-ia-java8 log to file
-  #     run: docker-compose -f test.yml logs -f engine-ia-java8 > engine-ia-java8.log &
-  #   - name: Sleep for 120 seconds
-  #     uses: whatnick/wait-action@master
-  #     with:
-  #       time: '120s'
-  #   - name: Test with Maven
-  #     timeout-minutes: 60
-  #     run: mvn -B -DfailIfNoTests=false -Dtest=org.opentosca.container.war.tests.${{ matrix.test }} test --file pom.xml --fail-at-end
-  #     env:
-  #       PlanqkApiKey: ${{ secrets.PLANQK_API_KEY }}
-  #       OrganizationID: "eecfa1d7-5f52-45d4-accc-b470ad05959f"
-  #   - name: Store engine-ia log
-  #     uses: actions/upload-artifact@v3
-  #     if: ${{ always() }}
-  #     with:
-  #       name: engine-ia-log
-  #       path: |
-  #         engine-ia-java17.log
-  #         engine-ia-java8.log
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: 17
+        cache: maven
+        distribution: temurin
+    - name: Check out TOSCA internal repository
+      uses: actions/checkout@v3
+      with:
+        repository: OpenTOSCA/tosca-definitions-test-applications
+        ref: 'main'
+        path: 'tosca-definitions-test-applications'
+        lfs: 'true'
+    - name: Copy TOSCA internal repository to tmp
+      run: cp -R $GITHUB_WORKSPACE/tosca-definitions-test-applications /tmp/
+    - name: Show TOSCA internal repository content
+      run: ls -a /tmp/tosca-definitions-test-applications
+    - name: Setup Docker Remote API
+      run: sudo sed -ie "s@ExecStart=\/usr\/bin\/dockerd -H fd:\/\/@ExecStart=\/usr\/bin\/dockerd -H fd:\/\/ -H tcp:\/\/0.0.0.0:2375 -H unix:///var/run/docker.sock@g" /lib/systemd/system/docker.service
+    - name: Reload Daemons
+      run: sudo systemctl daemon-reload
+    - name: Restart Docker
+      run: sudo service docker restart
+    - name: Configure runtime with test properties
+      run: cp test.properties ./org.opentosca.container.core/src/main/resources/application.properties
+    - name: Show application properties
+      run: cat ./org.opentosca.container.core/src/main/resources/application.properties
+    - name: Test Docker Remote API
+      run: curl -X GET http://localhost:2375/images/json
+    - name: Start test environment
+      run: docker-compose -f test.yml up -d
+    - name: Save engine-ia-java17 log to file
+      run: docker-compose -f test.yml logs -f engine-ia-java17 > engine-ia-java17.log &
+    - name: Save engine-ia-java8 log to file
+      run: docker-compose -f test.yml logs -f engine-ia-java8 > engine-ia-java8.log &
+    - name: Sleep for 120 seconds
+      uses: whatnick/wait-action@master
+      with:
+        time: '120s'
+    - name: Test with Maven
+      timeout-minutes: 60
+      run: mvn -B -DfailIfNoTests=false -Dtest=org.opentosca.container.war.tests.${{ matrix.test }} test --file pom.xml --fail-at-end
+      env:
+        PlanqkApiKey: ${{ secrets.PLANQK_API_KEY }}
+        OrganizationID: "eecfa1d7-5f52-45d4-accc-b470ad05959f"
+    - name: Store engine-ia log
+      uses: actions/upload-artifact@v3
+      if: ${{ always() }}
+      with:
+        name: engine-ia-log
+        path: |
+          engine-ia-java17.log
+          engine-ia-java8.log

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,76 +32,77 @@ jobs:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: org.opentosca.container.reporting/target/site/jacoco-aggregate/jacoco.xml
 
-  tests:
-    strategy:
-      matrix:
-        test: [] # TODO: reenable tests
-          # - AdaptMultiMyTinyToDoIntegrationTest
-          # - ApacheWebAppIntegrationTest
-          # - ConnectToIntegrationTest
-          # - MigrateMyTinyToDo2MultiMyTinyToDoIntegrationTest
-          # - MultiMyTinyToDoIntegrationTest
-          # - MyTinyToDoBPMNIntegrationTest
-          # - MyTinyToDoIntegrationTest
-          #- MyTinyToDoSqlIntegrationTest
-          #- PlanQKServiceIntegrationTest
-          # - QHAnaTest
-    runs-on: ubuntu-latest
-    timeout-minutes: 80
-    needs: build
+# TODO: reenable tests
+  # tests:
+  #   strategy:
+  #     matrix:
+  #       test: 
+  #         - AdaptMultiMyTinyToDoIntegrationTest
+  #         - ApacheWebAppIntegrationTest
+  #         - ConnectToIntegrationTest
+  #         - MigrateMyTinyToDo2MultiMyTinyToDoIntegrationTest
+  #         - MultiMyTinyToDoIntegrationTest
+  #         - MyTinyToDoBPMNIntegrationTest
+  #         - MyTinyToDoIntegrationTest
+  #         #- MyTinyToDoSqlIntegrationTest
+  #         #- PlanQKServiceIntegrationTest
+  #         - QHAnaTest
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 80
+  #   needs: build
 
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
-      with:
-        java-version: 17
-        cache: maven
-        distribution: temurin
-    - name: Check out TOSCA internal repository
-      uses: actions/checkout@v3
-      with:
-        repository: OpenTOSCA/tosca-definitions-test-applications
-        ref: 'main'
-        path: 'tosca-definitions-test-applications'
-        lfs: 'true'
-    - name: Copy TOSCA internal repository to tmp
-      run: cp -R $GITHUB_WORKSPACE/tosca-definitions-test-applications /tmp/
-    - name: Show TOSCA internal repository content
-      run: ls -a /tmp/tosca-definitions-test-applications
-    - name: Setup Docker Remote API
-      run: sudo sed -ie "s@ExecStart=\/usr\/bin\/dockerd -H fd:\/\/@ExecStart=\/usr\/bin\/dockerd -H fd:\/\/ -H tcp:\/\/0.0.0.0:2375 -H unix:///var/run/docker.sock@g" /lib/systemd/system/docker.service
-    - name: Reload Daemons
-      run: sudo systemctl daemon-reload
-    - name: Restart Docker
-      run: sudo service docker restart
-    - name: Configure runtime with test properties
-      run: cp test.properties ./org.opentosca.container.core/src/main/resources/application.properties
-    - name: Show application properties
-      run: cat ./org.opentosca.container.core/src/main/resources/application.properties
-    - name: Test Docker Remote API
-      run: curl -X GET http://localhost:2375/images/json
-    - name: Start test environment
-      run: docker-compose -f test.yml up -d
-    - name: Save engine-ia-java17 log to file
-      run: docker-compose -f test.yml logs -f engine-ia-java17 > engine-ia-java17.log &
-    - name: Save engine-ia-java8 log to file
-      run: docker-compose -f test.yml logs -f engine-ia-java8 > engine-ia-java8.log &
-    - name: Sleep for 120 seconds
-      uses: whatnick/wait-action@master
-      with:
-        time: '120s'
-    - name: Test with Maven
-      timeout-minutes: 60
-      run: mvn -B -DfailIfNoTests=false -Dtest=org.opentosca.container.war.tests.${{ matrix.test }} test --file pom.xml --fail-at-end
-      env:
-        PlanqkApiKey: ${{ secrets.PLANQK_API_KEY }}
-        OrganizationID: "eecfa1d7-5f52-45d4-accc-b470ad05959f"
-    - name: Store engine-ia log
-      uses: actions/upload-artifact@v3
-      if: ${{ always() }}
-      with:
-        name: engine-ia-log
-        path: |
-          engine-ia-java17.log
-          engine-ia-java8.log
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Set up JDK 17
+  #     uses: actions/setup-java@v3
+  #     with:
+  #       java-version: 17
+  #       cache: maven
+  #       distribution: temurin
+  #   - name: Check out TOSCA internal repository
+  #     uses: actions/checkout@v3
+  #     with:
+  #       repository: OpenTOSCA/tosca-definitions-test-applications
+  #       ref: 'main'
+  #       path: 'tosca-definitions-test-applications'
+  #       lfs: 'true'
+  #   - name: Copy TOSCA internal repository to tmp
+  #     run: cp -R $GITHUB_WORKSPACE/tosca-definitions-test-applications /tmp/
+  #   - name: Show TOSCA internal repository content
+  #     run: ls -a /tmp/tosca-definitions-test-applications
+  #   - name: Setup Docker Remote API
+  #     run: sudo sed -ie "s@ExecStart=\/usr\/bin\/dockerd -H fd:\/\/@ExecStart=\/usr\/bin\/dockerd -H fd:\/\/ -H tcp:\/\/0.0.0.0:2375 -H unix:///var/run/docker.sock@g" /lib/systemd/system/docker.service
+  #   - name: Reload Daemons
+  #     run: sudo systemctl daemon-reload
+  #   - name: Restart Docker
+  #     run: sudo service docker restart
+  #   - name: Configure runtime with test properties
+  #     run: cp test.properties ./org.opentosca.container.core/src/main/resources/application.properties
+  #   - name: Show application properties
+  #     run: cat ./org.opentosca.container.core/src/main/resources/application.properties
+  #   - name: Test Docker Remote API
+  #     run: curl -X GET http://localhost:2375/images/json
+  #   - name: Start test environment
+  #     run: docker-compose -f test.yml up -d
+  #   - name: Save engine-ia-java17 log to file
+  #     run: docker-compose -f test.yml logs -f engine-ia-java17 > engine-ia-java17.log &
+  #   - name: Save engine-ia-java8 log to file
+  #     run: docker-compose -f test.yml logs -f engine-ia-java8 > engine-ia-java8.log &
+  #   - name: Sleep for 120 seconds
+  #     uses: whatnick/wait-action@master
+  #     with:
+  #       time: '120s'
+  #   - name: Test with Maven
+  #     timeout-minutes: 60
+  #     run: mvn -B -DfailIfNoTests=false -Dtest=org.opentosca.container.war.tests.${{ matrix.test }} test --file pom.xml --fail-at-end
+  #     env:
+  #       PlanqkApiKey: ${{ secrets.PLANQK_API_KEY }}
+  #       OrganizationID: "eecfa1d7-5f52-45d4-accc-b470ad05959f"
+  #   - name: Store engine-ia log
+  #     uses: actions/upload-artifact@v3
+  #     if: ${{ always() }}
+  #     with:
+  #       name: engine-ia-log
+  #       path: |
+  #         engine-ia-java17.log
+  #         engine-ia-java8.log

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -44,7 +44,7 @@ jobs:
           - MyTinyToDoBPMNIntegrationTest
           - MyTinyToDoIntegrationTest
           #- MyTinyToDoSqlIntegrationTest
-          - PlanQKServiceIntegrationTest
+          #- PlanQKServiceIntegrationTest
           - QHAnaTest
     runs-on: ubuntu-latest
     timeout-minutes: 80


### PR DESCRIPTION
This PR
- replaces Docker Hub with the GitHub registry in the GitHub workflow and updates the used GitHub actions
- temporarily disables the PlanQK Service integration test as it's not compatible anymore with the platforms' authentication

Needed for https://github.com/OpenTOSCA/opentosca-docker/pull/57
